### PR TITLE
Add a hyperlink to Github Issues page in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ review in [this guide](docs/contributing.md).
 
 ## Support
 
-To report a bug or log a feature request, please open a GitHub issue and follow
-the guidelines for submitting a bug.
+To report a bug or log a feature request, please open a
+[GitHub issue](https://github.com/GoogleCloudPlatform/elcarro-oracle-operator/issues)
+and follow the guidelines for submitting a bug.
 
 For general questions or community support, we welcome you to join the
 [El Carro community mailing list](https://groups.google.com/forum/#!forum/el-carro)


### PR DESCRIPTION
The "github issues" text in the README.md file has been made a hyperlink to the actual issues page.