### PR TITLE
Refactor restore logic into a separate state machine

### DIFF
--- a/oracle/controllers/instancecontroller/BUILD.bazel
+++ b/oracle/controllers/instancecontroller/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "instance_controller.go",
         "instance_controller_parameters.go",
+        "instance_controller_restore.go",
         "instance_controller_standby.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers/instancecontroller",
@@ -24,6 +25,7 @@ go_library(
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",

--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -22,14 +22,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	lropb "google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +36,7 @@ import (
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
 	commonutils "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/pkg/utils"
-	v1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers/databasecontroller"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/agents/common/sql"
@@ -107,140 +105,6 @@ func restoreDOP(r, b int32) int32 {
 	}
 
 	return 1
-}
-
-// findBackupForRestore fetches the backup with the backup_id specified in the spec for initiating the instance restore.
-func (r *InstanceReconciler) findBackupForRestore(ctx context.Context, inst v1alpha1.Instance, namespace string) (*v1alpha1.Backup, error) {
-	var backups v1alpha1.BackupList
-	if err := r.List(ctx, &backups, client.InNamespace(namespace)); err != nil {
-		return nil, fmt.Errorf("preflight check: failed to list backups for a restore: %v", err)
-	}
-
-	var backup v1alpha1.Backup
-	for _, b := range backups.Items {
-		if b.Status.BackupID == inst.Spec.Restore.BackupID {
-			r.Log.V(1).Info("requested backup found")
-			backup = b
-		}
-	}
-
-	if backup.Spec.Type == "" {
-		return nil, fmt.Errorf("preflight check: failed to locate the requested backup %q", inst.Spec.Restore.BackupID)
-	}
-
-	if backup.Spec.Type != inst.Spec.Restore.BackupType {
-		return nil, fmt.Errorf("preflight check: located a backup of type %q, wanted: %q", backup.Spec.Type, inst.Spec.Restore.BackupType)
-	}
-
-	return &backup, nil
-}
-
-// restorePhysical runs the pre-flight checks and if all is good
-// it makes a gRPC call to a PhysicalRestore.
-func (r *InstanceReconciler) restorePhysical(ctx context.Context, inst v1alpha1.Instance, backup *v1alpha1.Backup, req ctrl.Request) (*lropb.Operation, error) {
-	// Confirm that an external LB is ready.
-	if err := restorePhysicalPreflightCheck(ctx, r, req.Namespace, inst.Name); err != nil {
-		return nil, err
-	}
-
-	if !*backup.Spec.Backupset {
-		return nil, fmt.Errorf("preflight check: located a physical backup, but in this release the auto-restore is only supported from a Backupset backup: %v", backup.Spec.Backupset)
-	}
-
-	if backup.Spec.Subtype != "Instance" {
-		return nil, fmt.Errorf("preflight check: located a physical backup, but in this release the auto-restore is only supported from a Backupset taken at the Instance level: %q", backup.Spec.Subtype)
-	}
-
-	backupReadyCond := k8s.FindCondition(backup.Status.Conditions, k8s.Ready)
-	if !k8s.ConditionStatusEquals(backupReadyCond, v1.ConditionTrue) {
-		return nil, fmt.Errorf("preflight check: located a physical backup, but it's not in the ready state: %q", backup.Status)
-	}
-	r.Log.Info("preflight check for a restore from a physical backup - all DONE", "backup", backup)
-
-	dop := restoreDOP(inst.Spec.Restore.Dop, backup.Spec.Dop)
-
-	caClient, closeConn, err := r.ClientFactory.New(ctx, r, req.Namespace, backup.Spec.Instance)
-	if err != nil {
-		r.Log.Error(err, "failed to create config agent client")
-		return nil, err
-	}
-	defer closeConn()
-
-	timeLimitMinutes := controllers.PhysBackupTimeLimitDefault * 3
-	if inst.Spec.Restore.TimeLimitMinutes != 0 {
-		timeLimitMinutes = time.Duration(inst.Spec.Restore.TimeLimitMinutes) * time.Minute
-	}
-
-	ctxRestore, cancel := context.WithTimeout(context.Background(), timeLimitMinutes)
-	defer cancel()
-
-	resp, err := caClient.PhysicalRestore(ctxRestore, &capb.PhysicalRestoreRequest{
-		InstanceName: inst.Name,
-		CdbName:      inst.Spec.CDBName,
-		Dop:          dop,
-		LocalPath:    backup.Spec.LocalPath,
-		GcsPath:      backup.Spec.GcsPath,
-		LroInput:     &capb.LROInput{OperationId: lroOperationID(physicalRestore, &inst)},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed on PhysicalRestore gRPC call: %v", err)
-	}
-
-	r.Log.Info("caClient.PhysicalRestore", "response", resp)
-	return resp, nil
-}
-
-// restoreSnapshot constructs the new PVCs and sets the restore in stsParams struct
-// based on the requested snapshot to restore from.
-func (r *InstanceReconciler) restoreSnapshot(ctx context.Context, inst v1alpha1.Instance, sts *appsv1.StatefulSet, sp *controllers.StsParams) error {
-	if err := r.Delete(ctx, sts); err != nil {
-		r.Log.Error(err, "restoreSnapshot: failed to delete the old StatefulSet")
-	}
-	r.Log.Info("restoreSnapshot: old StatefulSet deleted")
-
-	pvcs, err := controllers.NewPVCs(*sp)
-	if err != nil {
-		r.Log.Error(err, "NewPVCs failed")
-		return err
-	}
-	r.Log.Info("restoreSnapshot: old PVCs to delete constructed", "pvcs", pvcs)
-
-	for i, pvc := range pvcs {
-		pvc.Name = fmt.Sprintf("%s-%s-0", pvc.Name, sp.StsName)
-		if err := r.Delete(ctx, &pvc); err != nil {
-			r.Log.Error(err, "restoreSnapshot: failed to delete the old PVC", "pvc#", i, "pvc", pvc)
-		}
-		r.Log.Info("restoreSnapshot: old PVC deleted", "pvc", pvc.Name)
-
-		applyOpts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("instance-controller")}
-		if err := r.Patch(ctx, &pvc, client.Apply, applyOpts...); err != nil {
-			r.Log.Error(err, "restoreSnapshot: failed to patch the deleting of the old PVC")
-		}
-	}
-
-	sp.Restore = inst.Spec.Restore
-
-	newPVCs, err := controllers.NewPVCs(*sp)
-	if err != nil {
-		r.Log.Error(err, "NewPVCs failed")
-		return err
-	}
-	newPodTemplate := controllers.NewPodTemplate(*sp, inst.Spec.CDBName, controllers.GetDBDomain(&inst))
-	stsRestored, err := controllers.NewSts(*sp, newPVCs, newPodTemplate)
-	if err != nil {
-		r.Log.Error(err, "restoreSnapshot: failed to construct the restored StatefulSet")
-		return err
-	}
-	sts = stsRestored
-
-	applyOpts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("instance-controller")}
-	if err := r.Patch(ctx, sts, client.Apply, applyOpts...); err != nil {
-		r.Log.Error(err, "failed to patch the restored StatefulSet")
-		return err
-	}
-	r.Log.Info("restoreSnapshot: StatefulSet constructed", "statefulSet", sts, "sts.Status", sts.Status)
-
-	return nil
 }
 
 // loadConfig attempts to find a customer specific Operator config
@@ -439,11 +303,6 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		}
 	}
 
-	iReadyCond := k8s.FindCondition(inst.Status.Conditions, k8s.Ready)
-	if restoreInProgress(iReadyCond) {
-		return r.handleRestoreInProgress(ctx, req, &inst, iReadyCond, log)
-	}
-
 	// Load default preferences (aka "config") if provided by a customer.
 	config, err := r.loadConfig(ctx, req.NamespacedName.Namespace)
 	if err != nil {
@@ -490,37 +349,20 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		Services:       enabledServices,
 	}
 
-	var forceRestore bool
-
-	dbiCond := k8s.FindCondition(inst.Status.Conditions, k8s.DatabaseInstanceReady)
-	if (k8s.ConditionStatusEquals(iReadyCond, v1.ConditionTrue) && k8s.ConditionStatusEquals(dbiCond, v1.ConditionTrue)) ||
-		k8s.ConditionReasonEquals(iReadyCond, k8s.RestoreFailed) {
-
-		if inst.Spec.Restore == nil {
-			if k8s.ConditionStatusEquals(iReadyCond, v1.ConditionTrue) {
-				log.Info("instance has already been provisioned and ready")
-			} else {
-				log.Info("instance is in failed restore state")
-			}
-			return ctrl.Result{}, nil
+	// If there is a Restore section in the spec the reconciliation will be handled
+	// by restore state machine.
+	if inst.Spec.Restore != nil {
+		// Ask the restore state machine to reconcile
+		result, err := r.restoreStateMachine(req, instanceReadyCond, dbInstanceCond, &inst, ctx, sp)
+		if err != nil {
+			log.Error(err, "restoreStateMachine failed")
 		}
+		return result, err
+	}
 
-		if inst.Spec.Restore != nil {
-			if !inst.Spec.Restore.Force {
-				log.Info("instance is up and running. To replace (restore from a backup), set force=true")
-				return ctrl.Result{}, nil
-			}
-
-			requestTime := inst.Spec.Restore.RequestTime.Rfc3339Copy()
-			if inst.Status.LastRestoreTime != nil && !requestTime.After(inst.Status.LastRestoreTime.Time) {
-				log.Info(fmt.Sprintf("skipping the restore request as requestTime=%v is not later than the last restore time %v",
-					requestTime, inst.Status.LastRestoreTime.Time))
-				return ctrl.Result{}, nil
-			}
-
-			forceRestore = true
-			log.Info("force restore, replacing the original instance...")
-		}
+	if k8s.ConditionStatusEquals(instanceReadyCond, v1.ConditionTrue) && k8s.ConditionStatusEquals(dbInstanceCond, v1.ConditionTrue) {
+		log.Info("instance has already been provisioned and ready")
+		return ctrl.Result{}, nil
 	}
 
 	newPVCs, err := controllers.NewPVCs(sp)
@@ -534,11 +376,7 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		log.Error(err, "failed to create a StatefulSet", "sts", sts)
 		return ctrl.Result{}, err
 	}
-	log.V(1).Info("StatefulSet constructed", "sts", sts, "sts.Status", sts.Status, "inst.Status", inst.Status)
-
-	if forceRestore {
-		return r.forceRestore(ctx, req, &inst, iReadyCond, sts, sp, log)
-	}
+	log.Info("StatefulSet constructed", "sts", sts, "sts.Status", sts.Status, "inst.Status", inst.Status)
 
 	if err := r.Patch(ctx, sts, client.Apply, applyOpts...); err != nil {
 		log.Error(err, "failed to patch the StatefulSet", "sts.Status", sts.Status)
@@ -600,8 +438,8 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		return ctrl.Result{}, err
 	}
 
-	if iReadyCond == nil {
-		iReadyCond = k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.CreateInProgress, "")
+	if instanceReadyCond == nil {
+		instanceReadyCond = k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.CreateInProgress, "")
 	}
 
 	inst.Status.Endpoint = fmt.Sprintf(controllers.SvcEndpoint, fmt.Sprintf(controllers.SvcName, inst.Name), inst.Namespace)
@@ -610,8 +448,8 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 	// RequeueAfter 30 seconds to avoid constantly reconcile errors before statefulSet is ready.
 	// Update status when the Service is ready (for the initial provisioning).
 	// Also confirm that the StatefulSet is up and running.
-	if k8s.ConditionReasonEquals(iReadyCond, k8s.CreateInProgress) {
-		elapsed := k8s.ElapsedTimeFromLastTransitionTime(iReadyCond, time.Second)
+	if k8s.ConditionReasonEquals(instanceReadyCond, k8s.CreateInProgress) {
+		elapsed := k8s.ElapsedTimeFromLastTransitionTime(instanceReadyCond, time.Second)
 		if elapsed > instanceProvisionTimeout {
 			r.Recorder.Eventf(&inst, corev1.EventTypeWarning, "InstanceReady", fmt.Sprintf("Instance provision timed out after %v", instanceProvisionTimeout))
 			msg := fmt.Sprintf("Instance provision timed out. Elapsed Time: %v", elapsed)
@@ -626,7 +464,7 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		}
 
 		if inst.Status.URL != "" {
-			if !k8s.ConditionReasonEquals(iReadyCond, k8s.CreateComplete) {
+			if !k8s.ConditionReasonEquals(instanceReadyCond, k8s.CreateComplete) {
 				r.Recorder.Eventf(&inst, corev1.EventTypeNormal, "InstanceReady", "Instance has been created successfully. Elapsed Time: %v", elapsed)
 			}
 			k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.CreateComplete, "")
@@ -691,7 +529,7 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		log.V(1).Info("not a new DB, skipping the update", "dbName", newDB.Spec.Name)
 	}
 
-	log.Info("instance status", "iReadyCond", iReadyCond, "endpoint", inst.Status.Endpoint,
+	log.Info("instance status", "iReadyCond", instanceReadyCond, "endpoint", inst.Status.Endpoint,
 		"url", inst.Status.URL, "databases", inst.Status.DatabaseNames)
 
 	log.Info("reconciling instance: DONE")
@@ -723,11 +561,10 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		log.Info("Finished creating new CDB database")
 	}
 
-	dbiCond = k8s.FindCondition(inst.Status.Conditions, k8s.DatabaseInstanceReady)
 	if istatus != controllers.StatusReady {
 		log.Info("database instance doesn't appear to be ready yet...")
 
-		elapsed := k8s.ElapsedTimeFromLastTransitionTime(dbiCond, time.Second)
+		elapsed := k8s.ElapsedTimeFromLastTransitionTime(dbInstanceCond, time.Second)
 		if elapsed < createDatabaseInstanceTimeout {
 			log.Info(fmt.Sprintf("database instance creation in progress for %v, requeue after 30 seconds", elapsed))
 			k8s.InstanceUpsertCondition(&inst.Status, k8s.DatabaseInstanceReady, v1.ConditionFalse, k8s.CreateInProgress, "")
@@ -735,15 +572,17 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, respErr
 		}
 
 		log.Info(fmt.Sprintf("database instance creation timed out. Elapsed Time: %v", elapsed))
-		if !strings.Contains(dbiCond.Message, "Warning") { // so that we would create only one database instance timeout event
+		if !strings.Contains(dbInstanceCond.Message, "Warning") { // so that we would create only one database instance timeout event
 			r.Recorder.Eventf(&inst, corev1.EventTypeWarning, k8s.DatabaseInstanceTimeout, "DatabaseInstance has been in progress for over %v, please verify if it is stuck and should be recreated.", createDatabaseInstanceTimeout)
 		}
 		k8s.InstanceUpsertCondition(&inst.Status, k8s.DatabaseInstanceReady, v1.ConditionFalse, k8s.CreateInProgress, "Warning: db instance is taking a long time to start up - verify that instance has not failed")
 		return ctrl.Result{}, nil // return nil so reconcile loop would not retry
 	}
 
-	if !k8s.ConditionStatusEquals(dbiCond, v1.ConditionTrue) {
-		r.Recorder.Eventf(&inst, corev1.EventTypeNormal, k8s.DatabaseInstanceReady, "DatabaseInstance has been created successfully. Elapsed Time: %v", k8s.ElapsedTimeFromLastTransitionTime(dbiCond, time.Second))
+	if !k8s.ConditionStatusEquals(dbInstanceCond, v1.ConditionTrue) {
+		r.Recorder.Eventf(&inst, corev1.EventTypeNormal, k8s.DatabaseInstanceReady,
+			"DatabaseInstance has been created successfully. Elapsed Time: %v",
+			k8s.ElapsedTimeFromLastTransitionTime(dbInstanceCond, time.Second))
 	}
 
 	k8s.InstanceUpsertCondition(&inst.Status, k8s.DatabaseInstanceReady, v1.ConditionTrue, k8s.CreateComplete, "")
@@ -836,134 +675,6 @@ func (r *InstanceReconciler) overrideDefaultImages(config *v1alpha1.Config, imag
 	return ctrl.Result{}, nil
 }
 
-// forceRestore restores an instance from a backup. This method should be invoked
-// only when the force flag in restore spec is set to true.
-func (r *InstanceReconciler) forceRestore(ctx context.Context, req ctrl.Request, inst *v1alpha1.Instance, iReadyCond *v1.Condition, sts *appsv1.StatefulSet, sp controllers.StsParams, log logr.Logger) (ctrl.Result, error) {
-	k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestoreInProgress, fmt.Sprintf("Starting a restore on %s-%d from backup %s (type %s)", time.Now().Format(dateFormat), time.Now().Nanosecond(), inst.Spec.Restore.BackupID, inst.Spec.Restore.BackupType))
-	inst.Status.LastRestoreTime = inst.Spec.Restore.RequestTime.DeepCopy()
-	inst.Status.BackupID = ""
-
-	if err := r.Status().Update(ctx, inst); err != nil {
-		log.Error(err, "failed to update an Instance status (starting a restore)")
-		return ctrl.Result{}, err
-	}
-
-	backup, err := r.findBackupForRestore(ctx, *inst, req.Namespace)
-	if err != nil {
-		log.Error(err, "could not find a matching backup")
-		r.Recorder.Eventf(inst, corev1.EventTypeWarning, "RestoreFailed", "Could not find a matching backup for BackupID: %v, BackupType: %v", inst.Spec.Restore.BackupID, inst.Spec.Restore.BackupType)
-		k8s.InstanceUpsertCondition(&inst.Status, iReadyCond.Type, v1.ConditionFalse, k8s.RestoreFailed, err.Error())
-		return ctrl.Result{}, nil
-	}
-
-	switch inst.Spec.Restore.BackupType {
-	case "Snapshot":
-		if err := r.restoreSnapshot(ctx, *inst, sts, &sp); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("restore from a storage snapshot: DONE")
-
-	case "Physical":
-		operation, err := r.restorePhysical(ctx, *inst, backup, req)
-		if err != nil {
-			if !controllers.IsAlreadyExistsError(err) {
-				r.Log.Error(err, "PhysicalRestore failed")
-				return ctrl.Result{}, err
-			}
-		} else {
-			if operation.Done {
-				// we're dealing with non LRO version of restore
-				log.V(6).Info("encountered synchronous version of PhysicalRestore")
-				log.Info("PhysicalRestore DONE")
-
-				message := fmt.Sprintf("Physical restore done. Elapsed Time: %v", k8s.ElapsedTimeFromLastTransitionTime(k8s.FindCondition(inst.Status.Conditions, k8s.Ready), time.Second))
-				r.Recorder.Eventf(inst, corev1.EventTypeNormal, "RestoreComplete", message)
-				// non-LRO version sets condition to false, so that it will be set to true and cleaned up in the next reconcile loop
-				k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestoreComplete, message)
-			} else {
-				r.Log.Info("PhysicalRestore started")
-			}
-		}
-
-	default:
-		// Not playing games here. A restore (especially the in-place restore)
-		// is destructive. It's not about being user-friendly. A user is to
-		// be specific as to what kind of backup they want to restore from.
-		return ctrl.Result{}, fmt.Errorf("a BackupType is a mandatory parameter for a restore")
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func (r *InstanceReconciler) handleRestoreInProgress(ctx context.Context, req ctrl.Request,
-	inst *v1alpha1.Instance, iReadyCond *v1.Condition, log logr.Logger) (ctrl.Result, error) {
-
-	cleanupLROFunc := func() {}
-	// This is to prevent a panic if another thread already resets restore spec.
-	if inst.Spec.Restore != nil && inst.Spec.Restore.BackupType == "Physical" && !k8s.ConditionReasonEquals(iReadyCond, k8s.RestoreComplete) {
-		id := lroOperationID(physicalRestore, inst)
-		operation, err := controllers.GetLROOperation(r.ClientFactory, ctx, r, req.Namespace, id, inst.Name)
-		if err != nil {
-			log.Error(err, "GetLROOperation returned an error")
-			return ctrl.Result{}, err
-		}
-		log.Info("GetLROOperation", "response", operation)
-		if !operation.Done {
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
-		}
-
-		log.Info("LRO is DONE", "id", id)
-		cleanupLROFunc = func() {
-			_ = controllers.DeleteLROOperation(r.ClientFactory, ctx, r, req.Namespace, id, inst.Name)
-		}
-
-		// handle case when remote LRO completed unsuccessfully
-		if operation.GetError() != nil {
-			backupID := inst.Spec.Restore.BackupID
-			backupType := inst.Spec.Restore.BackupType
-
-			k8s.InstanceUpsertCondition(&inst.Status, iReadyCond.Type, v1.ConditionFalse, k8s.RestoreFailed, fmt.Sprintf("Failed to restore on %s-%d from backup %s (type %s): %s", time.Now().Format(dateFormat),
-				time.Now().Nanosecond(), backupID, backupType, operation.GetError().GetMessage()))
-			if err := r.Status().Update(ctx, inst); err != nil {
-				log.Error(err, "failed to update the instance status")
-				return ctrl.Result{}, err
-			}
-
-			inst.Spec.Restore = nil
-			if err := r.Update(ctx, inst); err != nil {
-				log.Error(err, "failed to update the Instance spec (record Restore Failure)")
-				return ctrl.Result{}, err
-			}
-			cleanupLROFunc()
-			return ctrl.Result{}, nil
-		}
-	} else if inst.Spec.Restore != nil && inst.Spec.Restore.BackupType == "Snapshot" {
-		if !r.updateProgressCondition(ctx, *inst, req.NamespacedName.Namespace, controllers.RestoreInProgress) {
-			log.Info("requeue after 30 seconds")
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
-	}
-	// This is to prevent a panic if another thread already resets restore spec.
-	if inst.Spec.Restore != nil {
-		backupID := inst.Spec.Restore.BackupID
-		backupType := inst.Spec.Restore.BackupType
-
-		inst.Spec.Restore = nil
-		if err := r.Update(ctx, inst); err != nil {
-			log.Error(err, "failed to update the Instance spec (removing the restore bit)")
-			return ctrl.Result{}, err
-		}
-		inst.Status.Description = fmt.Sprintf("Restored on %s-%d from backup %s (type %s)", time.Now().Format(dateFormat),
-			time.Now().Nanosecond(), backupID, backupType)
-		r.Recorder.Eventf(inst, corev1.EventTypeNormal, "RestoreComplete", inst.Status.Description)
-	}
-	cleanupLROFunc()
-
-	k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.RestoreComplete, "")
-
-	return ctrl.Result{}, nil
-}
-
 func diskSpecs(inst *v1alpha1.Instance, config *v1alpha1.Config) []commonv1alpha1.DiskSpec {
 	if inst != nil && inst.Spec.Disks != nil {
 		return inst.Spec.Disks
@@ -972,11 +683,6 @@ func diskSpecs(inst *v1alpha1.Instance, config *v1alpha1.Config) []commonv1alpha
 		return config.Spec.Disks
 	}
 	return defaultDisks
-}
-
-func restoreInProgress(instReadyCond *v1.Condition) bool {
-	return k8s.ConditionStatusEquals(instReadyCond, v1.ConditionFalse) &&
-		(k8s.ConditionReasonEquals(instReadyCond, k8s.RestoreComplete) || k8s.ConditionReasonEquals(instReadyCond, k8s.RestoreInProgress))
 }
 
 // bootstrapCDB is invoked during the instance creation phase for a database
@@ -1064,23 +770,4 @@ func (r *InstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&source.Kind{Type: &v1alpha1.Database{}},
 			&handler.EnqueueRequestForObject{}).
 		Complete(r)
-}
-
-func lroOperationID(opType string, instance *v1alpha1.Instance) string {
-	return fmt.Sprintf("%s_%s_%s", opType, instance.GetUID(), instance.Status.LastRestoreTime.Format(time.RFC3339))
-}
-
-// extracted for testing.
-var restorePhysicalPreflightCheck = func(ctx context.Context, r *InstanceReconciler, namespace, instName string) error {
-	svc := &corev1.Service{}
-	if err := r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(controllers.SvcName, instName), Namespace: namespace}, svc); err != nil {
-		return err
-	}
-
-	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		return fmt.Errorf("preflight check: physical backup: external LB is NOT ready")
-	}
-	r.Log.Info("preflight check: restore from a physical backup, external LB service is ready", "succeededExecCmd#:", 1, "svc", svc.Name)
-
-	return nil
 }

--- a/oracle/controllers/instancecontroller/instance_controller_restore.go
+++ b/oracle/controllers/instancecontroller/instance_controller_restore.go
@@ -1,0 +1,469 @@
+package instancecontroller
+
+import (
+	"context"
+	go_errors "errors"
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers"
+	capb "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/agents/config_agent/protos"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/k8s"
+	lropb "google.golang.org/genproto/googleapis/longrunning"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reconciler for restore logic.
+// Invoked when Spec.Restore is present.
+// State transition:
+// CreateComplete -> RestorePreparationInProgress -> RestorePreparationComplete ->
+// -> RestoreInProgress -> RestoreComplete
+// or ... -> RestoreFailed
+func (r *InstanceReconciler) restoreStateMachine(req ctrl.Request,
+	instanceReadyCond *v1.Condition,
+	dbInstanceCond *v1.Condition,
+	inst *v1alpha1.Instance,
+	ctx context.Context,
+	stsParams controllers.StsParams) (ctrl.Result, error) {
+
+	r.Log.Info("restoreStateMachine start")
+
+	// Conditions not initialized yet
+	if instanceReadyCond == nil || dbInstanceCond == nil || !k8s.ConditionStatusEquals(dbInstanceCond, v1.ConditionTrue) {
+		r.Log.Info("restoreStateMachine: Instance not ready yet, proceed with main reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	// Check the Force flag
+	if !inst.Spec.Restore.Force {
+		r.Log.Info("instance is up and running. To replace (restore from a backup), set force=true")
+		return ctrl.Result{}, nil
+	}
+
+	// Find the requested backup resource
+	backup, err := r.findBackupForRestore(ctx, *inst, req.Namespace)
+	if err != nil {
+		r.setRestoreFailed(ctx, inst, fmt.Sprintf(
+			"Could not find a matching backup for BackupID: %v, BackupType: %v",
+			inst.Spec.Restore.BackupID, inst.Spec.Restore.BackupType))
+		return ctrl.Result{}, nil
+	}
+
+	switch instanceReadyCond.Reason {
+	// Entry points for restore process
+	case k8s.RestoreComplete, k8s.CreateComplete:
+		if inst.Spec.Restore.BackupType != "Snapshot" && inst.Spec.Restore.BackupType != "Physical" {
+			// Not playing games here. A restore (especially the in-place restore)
+			// is destructive. It's not about being user-friendly. A user is to
+			// be specific as to what kind of backup they want to restore from.
+			r.Log.Error(fmt.Errorf("a BackupType is a mandatory parameter for a restore"), "stopping")
+			return ctrl.Result{}, nil
+		}
+
+		// Check the request time
+		requestTime := inst.Spec.Restore.RequestTime.Rfc3339Copy()
+		if inst.Status.LastRestoreTime != nil && !requestTime.After(inst.Status.LastRestoreTime.Time) {
+			r.Log.Info(fmt.Sprintf("skipping the restore request as requestTime=%v is not later than the last restore time %v",
+				requestTime, inst.Status.LastRestoreTime.Time))
+			return ctrl.Result{}, nil
+		}
+
+		inst.Status.LastRestoreTime = inst.Spec.Restore.RequestTime.DeepCopy()
+		inst.Status.BackupID = ""
+		k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestorePreparationInProgress, "")
+		if err := r.Status().Update(ctx, inst); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.Log.Info("restoreStateMachine: CreateComplete->RestorePreparationInProgress")
+		// Reconcile again
+		return ctrl.Result{Requeue: true}, nil
+	case k8s.RestorePreparationInProgress:
+		switch inst.Spec.Restore.BackupType {
+		case "Snapshot":
+			// Cleanup STS and PVCs.
+			done, err := r.cleanupSTSandPVC(ctx, *inst, stsParams)
+			if err != nil {
+				r.setRestoreFailed(ctx, inst, err.Error())
+				return ctrl.Result{}, err
+			}
+			if !done {
+				r.Log.Info("STS/PVC removal in progress, waiting")
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+			}
+		case "Physical":
+			// Do nothing in this step.
+		}
+		k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestorePreparationComplete, "")
+		r.Log.Info("restoreStateMachine: RestorePreparationInProgress->RestorePreparationComplete")
+		// Reconcile again
+		return ctrl.Result{Requeue: true}, nil
+	case k8s.RestorePreparationComplete:
+		// Update status and commit it to k8s before we proceed.
+		// This will protect us from a case where we start a restore job but fail to update our status.
+		k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestoreInProgress, "")
+		if err := r.Status().Update(ctx, inst); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.Log.Info("restoreStateMachine: RestorePreparationComplete->RestoreInProgress")
+		switch inst.Spec.Restore.BackupType {
+		case "Snapshot":
+			// Launch the restore process
+			if err := r.restoreSnapshot(ctx, *inst, stsParams); err != nil {
+				return ctrl.Result{}, err
+			}
+			r.Log.Info("restore from a storage snapshot: started")
+		case "Physical":
+			// Launch the LRO
+			operation, err := r.restorePhysical(ctx, *inst, backup, req)
+			if err != nil {
+				if !controllers.IsAlreadyExistsError(err) {
+					r.Log.Error(err, "PhysicalRestore failed")
+					return ctrl.Result{}, err
+				}
+			} else {
+				if operation.Done {
+					// we're dealing with non LRO version of restore
+					r.Log.Info("encountered synchronous version of PhysicalRestore")
+					r.Log.Info("PhysicalRestore DONE")
+					r.Log.Info("restoreStateMachine: CreateComplete->RestoreComplete")
+					message := fmt.Sprintf("Physical restore done. Elapsed Time: %v",
+						k8s.ElapsedTimeFromLastTransitionTime(k8s.FindCondition(inst.Status.Conditions, k8s.Ready), time.Second))
+					r.setRestoreSucceeded(ctx, inst, message)
+				} else {
+					r.Log.Info("PhysicalRestore started")
+				}
+			}
+		}
+		// Reconcile again
+		return ctrl.Result{Requeue: true}, nil
+	case k8s.RestoreInProgress:
+		done, err := false, error(nil)
+		switch inst.Spec.Restore.BackupType {
+		case "Snapshot":
+			done, err = r.isSnapshotRestoreDone(ctx, req, *inst)
+		case "Physical":
+			done, err = r.isPhysicalRestoreDone(ctx, req, *inst)
+			// Clean up LRO after we are done.
+			// The job will remain available for `ttlAfterDelete`.
+			if done {
+				id := lroOperationID(physicalRestore, *inst)
+				_ = controllers.DeleteLROOperation(r.ClientFactory, ctx, r, req.Namespace, id, inst.Name)
+			}
+		default:
+			r.setRestoreFailed(ctx, inst, "Unknown restore type")
+			return ctrl.Result{}, nil
+		}
+		if err != nil {
+			r.setRestoreFailed(ctx, inst, err.Error())
+			return ctrl.Result{}, err
+		}
+		if !done {
+			r.Log.Info("restore still in progress, waiting")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		r.Log.Info("restoreStateMachine: RestoreInProgress->RestoreComplete")
+		description := fmt.Sprintf("Restored on %s-%d from backup %s (type %s)", time.Now().Format(dateFormat),
+			time.Now().Nanosecond(), inst.Spec.Restore.BackupID, inst.Spec.Restore.BackupType)
+		r.setRestoreSucceeded(ctx, inst, description)
+	case k8s.RestoreFailed:
+		r.Log.Info("restoreStateMachine: instance is in failed restore state")
+	default:
+		r.Log.Info("restoreStateMachine: no action needed, proceed with main reconciliation")
+	}
+	return ctrl.Result{}, nil
+}
+
+// Update spec and status of the instance to reflect restore success.
+func (r *InstanceReconciler) setRestoreSucceeded(ctx context.Context, inst *v1alpha1.Instance, message string) {
+	r.Log.Info("Restore succeeded")
+	description := fmt.Sprintf("Restored on %s-%d from backup %s (type %s)", time.Now().Format(dateFormat),
+		time.Now().Nanosecond(), inst.Spec.Restore.BackupID, inst.Spec.Restore.BackupType)
+
+	// Create event.
+	r.Recorder.Eventf(inst, corev1.EventTypeWarning, "RestoreComplete", message)
+
+	// Remove restore spec. Update the inst object in place.
+	inst.Spec.Restore = nil
+	if err := r.Update(ctx, inst); err != nil {
+		r.Log.Error(err, "failed to update instance spec")
+	}
+	// Update status.
+	k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.RestoreComplete, message)
+	inst.Status.Description = description
+}
+
+// Update spec and status of the instance to reflect restore failure.
+func (r *InstanceReconciler) setRestoreFailed(ctx context.Context, inst *v1alpha1.Instance, reason string) {
+	r.Log.Error(go_errors.New(reason), "Restore failed")
+
+	// Create event.
+	r.Recorder.Eventf(inst, corev1.EventTypeWarning, "RestoreFailed", reason)
+
+	// Remove restore spec. Update the inst object in place.
+	inst.Spec.Restore = nil
+	if err := r.Update(ctx, inst); err != nil {
+		r.Log.Error(err, "failed to update instance spec")
+	}
+	// Update status.
+	k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.RestoreFailed, reason)
+}
+
+// Check for Snapshot restore status
+// Return (true, nil) if job is done
+// Return (false, nil) if job still in progress
+// Return (false, err) if the job failed
+func (r *InstanceReconciler) isSnapshotRestoreDone(ctx context.Context, req ctrl.Request,
+	inst v1alpha1.Instance) (bool, error) {
+
+	// Re-use STS progress function from instance controller.
+	// It will return err = nil when the STS creation is complete.
+	_, err := r.statusProgress(ctx, inst.Namespace, fmt.Sprintf(controllers.StsName, inst.Name))
+	r.Log.Info(fmt.Sprintf("Snapshot restore status: %s", err))
+	return err == nil, nil
+}
+
+// Check for Physical restore LRO job status
+// Return (true, nil) if LRO is done without errors.
+// Return (true, err) if LRO is done with an error.
+// Return (false, nil) if LRO still in progress.
+// Return (false, err) if other error occurred.
+func (r *InstanceReconciler) isPhysicalRestoreDone(ctx context.Context, req ctrl.Request,
+	inst v1alpha1.Instance) (bool, error) {
+
+	id := lroOperationID(physicalRestore, inst)
+	operation, err := controllers.GetLROOperation(r.ClientFactory, ctx, r, req.Namespace, id, inst.Name)
+	if err != nil {
+		r.Log.Error(err, "GetLROOperation returned an error")
+		return false, err
+	}
+	r.Log.Info("GetLROOperation", "response", operation)
+	if !operation.Done {
+		return false, nil
+	}
+
+	r.Log.Info("LRO is DONE, ", "id", id)
+
+	// handle case when remote LRO completed unsuccessfully
+	if operation.GetError() != nil {
+		backupID := inst.Spec.Restore.BackupID
+		backupType := inst.Spec.Restore.BackupType
+		return true, fmt.Errorf("Failed to restore on %s-%d from backup %s (type %s): %s. %v", time.Now().Format(dateFormat),
+			time.Now().Nanosecond(), backupID, backupType, operation.GetError().GetMessage(), err)
+	}
+	return true, nil
+}
+
+// extracted for testing.
+var restorePhysicalPreflightCheck = func(ctx context.Context, r *InstanceReconciler, namespace, instName string) error {
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(controllers.SvcName, instName), Namespace: namespace}, svc); err != nil {
+		return err
+	}
+
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return fmt.Errorf("preflight check: physical backup: external LB is NOT ready")
+	}
+	r.Log.Info("preflight check: restore from a physical backup, external LB service is ready", "succeededExecCmd#:", 1, "svc", svc.Name)
+
+	return nil
+}
+
+// restorePhysical runs the pre-flight checks and if all is good
+// it makes a gRPC call to a PhysicalRestore.
+func (r *InstanceReconciler) restorePhysical(ctx context.Context, inst v1alpha1.Instance, backup *v1alpha1.Backup, req ctrl.Request) (*lropb.Operation, error) {
+	// Confirm that an external LB is ready.
+	if err := restorePhysicalPreflightCheck(ctx, r, req.Namespace, inst.Name); err != nil {
+		return nil, err
+	}
+
+	if !*backup.Spec.Backupset {
+		return nil, fmt.Errorf("preflight check: located a physical backup, but in this release the auto-restore is only supported from a Backupset backup: %v", backup.Spec.Backupset)
+	}
+
+	if backup.Spec.Subtype != "Instance" {
+		return nil, fmt.Errorf("preflight check: located a physical backup, but in this release the auto-restore is only supported from a Backupset taken at the Instance level: %q", backup.Spec.Subtype)
+	}
+
+	backupReadyCond := k8s.FindCondition(backup.Status.Conditions, k8s.Ready)
+	if !k8s.ConditionStatusEquals(backupReadyCond, v1.ConditionTrue) {
+		return nil, fmt.Errorf("preflight check: located a physical backup, but it's not in the ready state: %q", backup.Status)
+	}
+	r.Log.Info("preflight check for a restore from a physical backup - all DONE", "backup", backup)
+
+	dop := restoreDOP(inst.Spec.Restore.Dop, backup.Spec.Dop)
+
+	caClient, closeConn, err := r.ClientFactory.New(ctx, r, req.Namespace, backup.Spec.Instance)
+	if err != nil {
+		r.Log.Error(err, "failed to create config agent client")
+		return nil, err
+	}
+	defer closeConn()
+
+	timeLimitMinutes := controllers.PhysBackupTimeLimitDefault * 3
+	if inst.Spec.Restore.TimeLimitMinutes != 0 {
+		timeLimitMinutes = time.Duration(inst.Spec.Restore.TimeLimitMinutes) * time.Minute
+	}
+
+	ctxRestore, cancel := context.WithTimeout(context.Background(), timeLimitMinutes)
+	defer cancel()
+
+	resp, err := caClient.PhysicalRestore(ctxRestore, &capb.PhysicalRestoreRequest{
+		InstanceName: inst.Name,
+		CdbName:      inst.Spec.CDBName,
+		Dop:          dop,
+		LocalPath:    backup.Spec.LocalPath,
+		GcsPath:      backup.Spec.GcsPath,
+		LroInput:     &capb.LROInput{OperationId: lroOperationID(physicalRestore, inst)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed on PhysicalRestore gRPC call: %v", err)
+	}
+
+	r.Log.Info("caClient.PhysicalRestore", "LRO", lroOperationID(physicalRestore, inst), "response", resp)
+	return resp, nil
+}
+
+// Create STS and PVC objects from given sts params.
+func (r *InstanceReconciler) createSTSandPVC(ctx context.Context,
+	inst v1alpha1.Instance, sp controllers.StsParams) (error, *appsv1.StatefulSet, []corev1.PersistentVolumeClaim) {
+	// Create PVCs.
+	newPVCs, err := controllers.NewPVCs(sp)
+	if err != nil {
+		r.Log.Error(err, "NewPVCs failed")
+		return err, nil, nil
+	}
+	// Create STS
+	newPodTemplate := controllers.NewPodTemplate(sp, inst.Spec.CDBName, controllers.GetDBDomain(&inst))
+	sts, err := controllers.NewSts(sp, newPVCs, newPodTemplate)
+	if err != nil {
+		r.Log.Error(err, "failed to create a StatefulSet", "sts", sts)
+		return err, nil, nil
+	}
+	r.Log.Info("StatefulSet constructed", "sts", sts, "sts.Status", sts.Status, "inst.Status", inst.Status)
+	return nil, sts, newPVCs
+}
+
+// cleanupSTSandPVCs removes old STS and PVCs before restoring from snapshot.
+// Return (true, nil) if all done.
+// Return (false, nil) if still in progress.
+// Return (false, err) if unrecoverable error occurred.
+func (r *InstanceReconciler) cleanupSTSandPVC(ctx context.Context,
+	inst v1alpha1.Instance, sp controllers.StsParams) (bool, error) {
+	// Create PVC and STS objects from sts params.
+	err, sts, newPVCs := r.createSTSandPVC(ctx, inst, sp)
+	if err != nil {
+		r.Log.Error(err, "failed to create a StatefulSet")
+		return false, err
+	}
+
+	// Check if old STS still exists.
+	existingSTS := appsv1.StatefulSet{}
+	stsKey := client.ObjectKey{Namespace: sts.Namespace, Name: sts.Name}
+	err = r.Get(ctx, stsKey, &existingSTS)
+
+	// If STS exists delete it and restart reconciling.
+	if err == nil {
+		r.Log.Info("deleting sts", "name", sts.Name)
+		if err := r.Delete(ctx, sts); err != nil {
+			r.Log.Error(err, "restoreSnapshot: failed to delete the old STS")
+		}
+		r.Log.Info("deleted STS, need to reconcile again")
+		return false, nil
+	} else if errors.IsNotFound(err) {
+		// Object is gone
+	} else {
+		// Other unrecoverable error
+		r.Log.Error(err, "unrecoverable error")
+		return false, err
+	}
+
+	for i, pvc := range newPVCs {
+		pvc.Name = fmt.Sprintf("%s-%s-0", pvc.Name, sp.StsName)
+
+		// Check if this PVC still exists.
+		existingPVC := corev1.PersistentVolumeClaim{}
+		pvcKey := client.ObjectKey{Namespace: pvc.Namespace, Name: pvc.Name}
+		err := r.Get(ctx, pvcKey, &existingPVC)
+
+		// If PVC exists delete it and restart reconciling.
+		if err == nil {
+			r.Log.Info("deleting pvc", "name", pvc.Name)
+			if err := r.Delete(ctx, &pvc); err != nil {
+				r.Log.Error(err, "cleanupSTSandPVCs: failed to delete the old PVC", "pvc#", i, "pvc", pvc)
+			}
+			r.Log.Info("deleted PVC, need to reconcile again")
+			return false, nil
+		} else if errors.IsNotFound(err) {
+			// Object is gone
+		} else {
+			// Other unrecoverable error
+			r.Log.Error(err, "Unrecoverable error")
+			return false, err
+		}
+	}
+	r.Log.Info("All old STS and PVCs are gone.")
+	return true, nil
+}
+
+// restoreSnapshot constructs the new PVCs and sets the restore in stsParams struct
+// based on the requested snapshot to restore from.
+func (r *InstanceReconciler) restoreSnapshot(ctx context.Context,
+	inst v1alpha1.Instance, sp controllers.StsParams) error {
+
+	// Set Restore field in sts params.
+	sp.Restore = inst.Spec.Restore
+
+	// Create PVC and STS objects from sts params (will use restore logic).
+	err, sts, _ := r.createSTSandPVC(ctx, inst, sp)
+	if err != nil {
+		r.Log.Error(err, "failed to create a StatefulSet")
+		return err
+	}
+
+	applyOpts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("instance-controller")}
+	if err := r.Patch(ctx, sts, client.Apply, applyOpts...); err != nil {
+		r.Log.Error(err, "failed to patch the restored StatefulSet")
+		return err
+	}
+	r.Log.Info("restoreSnapshot: updated StatefulSet created", "statefulSet", sts, "sts.Status", sts.Status)
+
+	return nil
+}
+
+// findBackupForRestore fetches the backup with the backup_id specified in the spec for initiating the instance restore.
+func (r *InstanceReconciler) findBackupForRestore(ctx context.Context, inst v1alpha1.Instance, namespace string) (*v1alpha1.Backup, error) {
+	var backups v1alpha1.BackupList
+	if err := r.List(ctx, &backups, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("preflight check: failed to list backups for a restore: %v", err)
+	}
+
+	var backup v1alpha1.Backup
+	for _, b := range backups.Items {
+		if b.Status.BackupID == inst.Spec.Restore.BackupID {
+			r.Log.Info("requested backup found")
+			backup = b
+		}
+	}
+
+	if backup.Spec.Type == "" {
+		return nil, fmt.Errorf("preflight check: failed to locate the requested backup %q", inst.Spec.Restore.BackupID)
+	}
+
+	if backup.Spec.Type != inst.Spec.Restore.BackupType {
+		return nil, fmt.Errorf("preflight check: located a backup of type %q, wanted: %q", backup.Spec.Type, inst.Spec.Restore.BackupType)
+	}
+
+	return &backup, nil
+}
+
+func lroOperationID(opType string, instance v1alpha1.Instance) string {
+	return fmt.Sprintf("%s_%s_%s", opType, instance.GetUID(), instance.Status.LastRestoreTime.Format(time.RFC3339))
+}

--- a/oracle/pkg/k8s/condition.go
+++ b/oracle/pkg/k8s/condition.go
@@ -46,6 +46,8 @@ const (
 	ImportPending                  = "ImportPending"
 	RestoreComplete                = "RestoreComplete"
 	RestoreFailed                  = "RestoreFailed"
+	RestorePreparationInProgress   = "RestorePreparationInProgress"
+	RestorePreparationComplete     = "RestorePreparationComplete"
 	RestoreInProgress              = "RestoreInProgress"
 	SyncInProgress                 = "SyncInProgress"
 	UserOutOfSync                  = "UserOutOfSync"


### PR DESCRIPTION
* Move everything restore-related to instance_controller_restore.go
* Simplify code flow and readability
* Add 2 extra statuses RestorePreparationInProgress / RestorePreparationComplete. This helps keep track of old STS/PVC removal.
* Minor tweaks to functional tests (delete LRO might be called more than once, this is expected)
* This should fix bug/flake '[pvc] is being deleted'
