### PR TITLE
Fix data races in FakeConfigAgentClient.

### DIFF
--- a/oracle/controllers/backupcontroller/backup_controller_test.go
+++ b/oracle/controllers/backupcontroller/backup_controller_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Backup controller", func() {
 			Eventually(func() (string, error) {
 				return getConditionReason(ctx, objKey, k8s.Ready)
 			}, timeout, interval).Should(Equal(k8s.BackupReady))
-			Expect(fakeClientFactory.Caclient.PhysicalBackupCalledCnt).Should(Equal(1))
+			Expect(fakeClientFactory.Caclient.PhysicalBackupCalledCnt()).Should(Equal(1))
 		})
 	})
 
@@ -233,8 +233,8 @@ var _ = Describe("Backup controller", func() {
 
 			// configure fake ConfigAgent to be in LRO mode
 			fakeConfigAgentClient := fakeClientFactory.Caclient
-			fakeConfigAgentClient.AsyncPhysicalBackup = true
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusRunning
+			fakeConfigAgentClient.SetAsyncPhysicalBackup(true)
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusRunning)
 
 			By("By creating a RMAN type backup of the instance")
 			backup := &v1alpha1.Backup{
@@ -260,14 +260,14 @@ var _ = Describe("Backup controller", func() {
 			Eventually(func() (string, error) {
 				return getConditionReason(ctx, objKey, k8s.Ready)
 			}, timeout, interval).Should(Equal(k8s.BackupInProgress))
-			Expect(fakeConfigAgentClient.PhysicalBackupCalledCnt).Should(Equal(1))
+			Expect(fakeConfigAgentClient.PhysicalBackupCalledCnt()).Should(Equal(1))
 
 			By("By checking that reconciler watches backup LRO status")
-			getOperationCallsCntBefore := fakeConfigAgentClient.GetOperationCalledCnt
+			getOperationCallsCntBefore := fakeConfigAgentClient.GetOperationCalledCnt()
 
 			Expect(triggerReconcile(ctx, objKey)).Should(Succeed())
 			Eventually(func() int {
-				return fakeConfigAgentClient.GetOperationCalledCnt
+				return fakeConfigAgentClient.GetOperationCalledCnt()
 			}, timeout, interval).ShouldNot(Equal(getOperationCallsCntBefore))
 
 			var updatedBackup v1alpha1.Backup
@@ -275,7 +275,7 @@ var _ = Describe("Backup controller", func() {
 			Expect(k8s.FindCondition(updatedBackup.Status.Conditions, k8s.Ready).Reason).Should(Equal(k8s.BackupInProgress))
 
 			By("By checking that physical backup is Ready on backup LRO completion")
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDone
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDone)
 			Expect(triggerReconcile(ctx, objKey)).Should(Succeed())
 			Eventually(func() (string, error) {
 				return getConditionReason(ctx, objKey, k8s.Ready)
@@ -294,8 +294,8 @@ var _ = Describe("Backup controller", func() {
 			// configure fake ConfigAgent to be in LRO mode with a
 			// failed operation result.
 			fakeConfigAgentClient := fakeClientFactory.Caclient
-			fakeConfigAgentClient.AsyncPhysicalBackup = true
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDoneWithError
+			fakeConfigAgentClient.SetAsyncPhysicalBackup(true)
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDoneWithError)
 
 			By("By creating a RMAN type backup of the instance")
 			backup := &v1alpha1.Backup{

--- a/oracle/controllers/exportcontroller/export_controller_test.go
+++ b/oracle/controllers/exportcontroller/export_controller_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
-	v1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers/testhelpers"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/k8s"
 )
@@ -177,7 +177,7 @@ var _ = Describe("Export controller", func() {
 			SetDatabaseReadyStatus(metav1.ConditionTrue)
 
 			By("setting LRO status to Done")
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDone
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDone)
 
 			CreateExport()
 
@@ -195,7 +195,7 @@ var _ = Describe("Export controller", func() {
 			SetDatabaseReadyStatus(metav1.ConditionTrue)
 
 			By("setting LRO status to DoneWithError")
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDoneWithError
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDoneWithError)
 
 			CreateExport()
 

--- a/oracle/controllers/importcontroller/import_controller_test.go
+++ b/oracle/controllers/importcontroller/import_controller_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Import controller", func() {
 
 		It("Should succeed when LRO completes successfully", func() {
 			By("simulating successful DataPumpImport LRO completion")
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDone
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDone)
 
 			By("creating a new import")
 			Expect(k8sClient.Create(ctx, imp)).Should(Succeed())
@@ -172,7 +172,7 @@ var _ = Describe("Import controller", func() {
 
 		It("Should handle LRO failure", func() {
 			By("simulating failed DataPumpImport LRO completion")
-			fakeConfigAgentClient.NextGetOperationStatus = testhelpers.StatusDoneWithError
+			fakeConfigAgentClient.SetNextGetOperationStatus(testhelpers.StatusDoneWithError)
 
 			By("creating a new import")
 			Expect(k8sClient.Create(ctx, imp)).Should(Succeed())

--- a/oracle/controllers/testhelpers/grpcmocks.go
+++ b/oracle/controllers/testhelpers/grpcmocks.go
@@ -17,6 +17,8 @@ package testhelpers
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/genproto/googleapis/longrunning"
@@ -31,7 +33,7 @@ import (
 )
 
 // FakeOperationStatus is an enum type for LRO statuses managed by FakeConfigAgentClient.
-type FakeOperationStatus int
+type FakeOperationStatus int32
 
 const (
 	//StatusUndefined undefined.
@@ -48,31 +50,33 @@ const (
 
 // FakeConfigAgentClient a client for capturing calls the various ConfigAgent api.
 type FakeConfigAgentClient struct {
-	PhysicalBackupCalledCnt        int
-	PhysicalRestoreCalledCnt       int
-	CreateDatabaseCalledCnt        int
-	CreateUsersCalledCnt           int
-	UsersChangedCalledCnt          int
-	UpdateUsersCalledCnt           int
-	CheckStatusCalledCnt           int
-	CreateCDBCalledCnt             int
-	BootstrapCDBCalledCnt          int
-	BootstrapDatabaseCalledCnt     int
-	BootstrapStandbyCalledCnt      int
-	BounceDatabaseCalledCnt        int
-	CreateListenerCalledCnt        int
-	ListOperationsCalledCnt        int
-	GetOperationCalledCnt          int
-	deleteOperationCalledCnt       int
-	dataPumpImportCalledCnt        int
-	dataPumpExportCalledCnt        int
-	SetParameterCalledCnt          int
-	GetParameterTypeValueCalledCnt int
-	RecoverConfigFileCalledCnt     int
-	AsyncPhysicalBackup            bool
-	AsyncPhysicalRestore           bool
-	FetchServiceImageMetaDataCnt   int
-	NextGetOperationStatus         FakeOperationStatus
+	physicalBackupCalledCnt        int32
+	physicalRestoreCalledCnt       int32
+	createDatabaseCalledCnt        int32
+	createUsersCalledCnt           int32
+	usersChangedCalledCnt          int32
+	updateUsersCalledCnt           int32
+	checkStatusCalledCnt           int32
+	createCDBCalledCnt             int32
+	bootstrapCDBCalledCnt          int32
+	bootstrapDatabaseCalledCnt     int32
+	bootstrapStandbyCalledCnt      int32
+	bounceDatabaseCalledCnt        int32
+	createListenerCalledCnt        int32
+	listOperationsCalledCnt        int32
+	getOperationCalledCnt          int32
+	deleteOperationCalledCnt       int32
+	dataPumpImportCalledCnt        int32
+	dataPumpExportCalledCnt        int32
+	setParameterCalledCnt          int32
+	getParameterTypeValueCalledCnt int32
+	recoverConfigFileCalledCnt     int32
+
+	lock                         sync.Mutex
+	fetchServiceImageMetaDataCnt int32
+	asyncPhysicalBackup          bool
+	asyncPhysicalRestore         bool
+	nextGetOperationStatus       FakeOperationStatus
 }
 
 var (
@@ -104,69 +108,69 @@ func (cli *FakeConfigAgentClient) Reset() {
 
 // CreateDatabase wrapper.
 func (cli *FakeConfigAgentClient) CreateDatabase(context.Context, *capb.CreateDatabaseRequest, ...grpc.CallOption) (*capb.CreateDatabaseResponse, error) {
-	cli.CreateCDBCalledCnt++
+	atomic.AddInt32(&cli.createCDBCalledCnt, 1)
 	return nil, nil
 }
 
 // CreateUsers wrapper.
 func (cli *FakeConfigAgentClient) CreateUsers(context.Context, *capb.CreateUsersRequest, ...grpc.CallOption) (*capb.CreateUsersResponse, error) {
-	cli.CreateUsersCalledCnt++
+	atomic.AddInt32(&cli.createUsersCalledCnt, 1)
 	return nil, nil
 }
 
 // UsersChanged wrapper.
 func (cli *FakeConfigAgentClient) UsersChanged(context.Context, *capb.UsersChangedRequest, ...grpc.CallOption) (*capb.UsersChangedResponse, error) {
-	cli.UsersChangedCalledCnt++
+	atomic.AddInt32(&cli.usersChangedCalledCnt, 1)
 	return nil, nil
 }
 
 // UpdateUsers wrapper.
 func (cli *FakeConfigAgentClient) UpdateUsers(context.Context, *capb.UpdateUsersRequest, ...grpc.CallOption) (*capb.UpdateUsersResponse, error) {
-	cli.UpdateUsersCalledCnt++
+	atomic.AddInt32(&cli.updateUsersCalledCnt, 1)
 	return nil, nil
 }
 
 // PhysicalBackup wrapper.
 func (cli *FakeConfigAgentClient) PhysicalBackup(context.Context, *capb.PhysicalBackupRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.PhysicalBackupCalledCnt++
-	return &longrunning.Operation{Done: !cli.AsyncPhysicalBackup}, nil
+	atomic.AddInt32(&cli.physicalBackupCalledCnt, 1)
+	return &longrunning.Operation{Done: !cli.asyncPhysicalBackup}, nil
 }
 
 // PhysicalRestore wrapper.
 func (cli *FakeConfigAgentClient) PhysicalRestore(context.Context, *capb.PhysicalRestoreRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.PhysicalRestoreCalledCnt++
-	return &longrunning.Operation{Done: !cli.AsyncPhysicalRestore}, nil
+	atomic.AddInt32(&cli.physicalRestoreCalledCnt, 1)
+	return &longrunning.Operation{Done: !cli.asyncPhysicalRestore}, nil
 }
 
 // CheckStatus wrapper.
 func (cli *FakeConfigAgentClient) CheckStatus(context.Context, *capb.CheckStatusRequest, ...grpc.CallOption) (*capb.CheckStatusResponse, error) {
-	cli.CheckStatusCalledCnt++
+	atomic.AddInt32(&cli.checkStatusCalledCnt, 1)
 	return nil, nil
 }
 
 // CreateCDB wrapper.
 func (cli *FakeConfigAgentClient) CreateCDB(context.Context, *capb.CreateCDBRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.CreateCDBCalledCnt++
+	atomic.AddInt32(&cli.createCDBCalledCnt, 1)
 	return nil, nil
 }
 
 // CreateListener wrapper.
 func (cli *FakeConfigAgentClient) CreateListener(context.Context, *capb.CreateListenerRequest, ...grpc.CallOption) (*capb.CreateListenerResponse, error) {
-	cli.CreateListenerCalledCnt++
+	atomic.AddInt32(&cli.createListenerCalledCnt, 1)
 	return nil, nil
 }
 
 // ListOperations wrapper.
 func (cli *FakeConfigAgentClient) ListOperations(context.Context, *longrunning.ListOperationsRequest, ...grpc.CallOption) (*longrunning.ListOperationsResponse, error) {
-	cli.ListOperationsCalledCnt++
+	atomic.AddInt32(&cli.listOperationsCalledCnt, 1)
 	return nil, nil
 }
 
 // GetOperation wrapper.
 func (cli *FakeConfigAgentClient) GetOperation(context.Context, *longrunning.GetOperationRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.GetOperationCalledCnt++
+	atomic.AddInt32(&cli.getOperationCalledCnt, 1)
 
-	switch cli.NextGetOperationStatus {
+	switch cli.NextGetOperationStatus() {
 	case StatusDone:
 		return &longrunning.Operation{Done: true}, nil
 
@@ -188,86 +192,122 @@ func (cli *FakeConfigAgentClient) GetOperation(context.Context, *longrunning.Get
 		panic("Misconfigured test, set up expected operation status")
 
 	default:
-		panic(fmt.Sprintf("unknown status: %v", cli.NextGetOperationStatus))
+		panic(fmt.Sprintf("unknown status: %v", cli.NextGetOperationStatus()))
 	}
 }
 
 // DeleteOperation wrapper.
 func (cli *FakeConfigAgentClient) DeleteOperation(context.Context, *longrunning.DeleteOperationRequest, ...grpc.CallOption) (*empty.Empty, error) {
-	cli.deleteOperationCalledCnt++
+	atomic.AddInt32(&cli.deleteOperationCalledCnt, 1)
 	return nil, nil
 }
 
 // CreateCDBUser wrapper.
 func (cli *FakeConfigAgentClient) CreateCDBUser(context.Context, *capb.CreateCDBUserRequest, ...grpc.CallOption) (*capb.CreateCDBUserResponse, error) {
-	cli.CreateListenerCalledCnt++
+	atomic.AddInt32(&cli.createListenerCalledCnt, 1)
 	return nil, nil
 }
 
 // BootstrapDatabase wrapper.
 func (cli *FakeConfigAgentClient) BootstrapDatabase(context.Context, *capb.BootstrapDatabaseRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.BootstrapDatabaseCalledCnt++
+	atomic.AddInt32(&cli.bootstrapDatabaseCalledCnt, 1)
 	return nil, nil
 }
 
 // BootstrapStandby wrapper.
 func (cli *FakeConfigAgentClient) BootstrapStandby(context.Context, *capb.BootstrapStandbyRequest, ...grpc.CallOption) (*capb.BootstrapStandbyResponse, error) {
-	cli.BootstrapStandbyCalledCnt++
+	atomic.AddInt32(&cli.bootstrapStandbyCalledCnt, 1)
 	return nil, nil
 }
 
 // DataPumpImport wrapper.
 func (cli *FakeConfigAgentClient) DataPumpImport(context.Context, *capb.DataPumpImportRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.dataPumpImportCalledCnt++
+	atomic.AddInt32(&cli.dataPumpImportCalledCnt, 1)
 	return &longrunning.Operation{Done: false}, nil
 }
 
 // DataPumpExport wrapper.
 func (cli *FakeConfigAgentClient) DataPumpExport(context.Context, *capb.DataPumpExportRequest, ...grpc.CallOption) (*longrunning.Operation, error) {
-	cli.dataPumpExportCalledCnt++
+	atomic.AddInt32(&cli.dataPumpExportCalledCnt, 1)
 	return nil, nil
 }
 
 // BounceDatabase wrapper.
 func (cli *FakeConfigAgentClient) BounceDatabase(context.Context, *capb.BounceDatabaseRequest, ...grpc.CallOption) (*capb.BounceDatabaseResponse, error) {
-	cli.BounceDatabaseCalledCnt++
+	atomic.AddInt32(&cli.bounceDatabaseCalledCnt, 1)
 	return nil, nil
 }
 
-// DataPumpImportCalledCnt return call count.
+// DataPumpImportCalledCnt returns call count.
 func (cli *FakeConfigAgentClient) DataPumpImportCalledCnt() int {
-	return cli.dataPumpImportCalledCnt
+	return int(atomic.LoadInt32(&cli.dataPumpImportCalledCnt))
 }
 
-// DataPumpExportCalledCnt return call count.
+// DataPumpExportCalledCnt returns call count.
 func (cli *FakeConfigAgentClient) DataPumpExportCalledCnt() int {
-	return cli.dataPumpExportCalledCnt
+	return int(atomic.LoadInt32(&cli.dataPumpExportCalledCnt))
 }
 
-// DeleteOperationCalledCnt return call count.
+// DeleteOperationCalledCnt returns call count.
 func (cli *FakeConfigAgentClient) DeleteOperationCalledCnt() int {
-	return cli.deleteOperationCalledCnt
+	return int(atomic.LoadInt32(&cli.deleteOperationCalledCnt))
+}
+
+func (cli *FakeConfigAgentClient) PhysicalBackupCalledCnt() int {
+	return int(atomic.LoadInt32(&cli.physicalBackupCalledCnt))
+}
+
+func (cli *FakeConfigAgentClient) PhysicalRestoreCalledCnt() int {
+	return int(atomic.LoadInt32(&cli.physicalRestoreCalledCnt))
+}
+
+func (cli *FakeConfigAgentClient) GetOperationCalledCnt() int {
+	return int(atomic.LoadInt32(&cli.getOperationCalledCnt))
 }
 
 // SetParameter wrapper.
 func (cli *FakeConfigAgentClient) SetParameter(context.Context, *capb.SetParameterRequest, ...grpc.CallOption) (*capb.SetParameterResponse, error) {
-	cli.SetParameterCalledCnt++
+	atomic.AddInt32(&cli.setParameterCalledCnt, 1)
 	return nil, nil
 }
 
 // GetParameterTypeValue wrapper.
 func (cli *FakeConfigAgentClient) GetParameterTypeValue(context.Context, *capb.GetParameterTypeValueRequest, ...grpc.CallOption) (*capb.GetParameterTypeValueResponse, error) {
-	cli.GetParameterTypeValueCalledCnt++
+	atomic.AddInt32(&cli.getParameterTypeValueCalledCnt, 1)
 	return nil, nil
 }
 
 // RecoverConfigFile wrapper.
 func (cli *FakeConfigAgentClient) RecoverConfigFile(ctx context.Context, in *capb.RecoverConfigFileRequest, opts ...grpc.CallOption) (*capb.RecoverConfigFileResponse, error) {
-	cli.RecoverConfigFileCalledCnt++
+	atomic.AddInt32(&cli.recoverConfigFileCalledCnt, 1)
 	return nil, nil
 }
 
 func (cli *FakeConfigAgentClient) FetchServiceImageMetaData(ctx context.Context, in *capb.FetchServiceImageMetaDataRequest, opts ...grpc.CallOption) (*capb.FetchServiceImageMetaDataResponse, error) {
-	cli.FetchServiceImageMetaDataCnt++
+	atomic.AddInt32(&cli.fetchServiceImageMetaDataCnt, 1)
 	return nil, nil
+}
+
+func (cli *FakeConfigAgentClient) SetNextGetOperationStatus(status FakeOperationStatus) {
+	cli.lock.Lock()
+	defer cli.lock.Unlock()
+	cli.nextGetOperationStatus = status
+}
+
+func (cli *FakeConfigAgentClient) NextGetOperationStatus() FakeOperationStatus {
+	cli.lock.Lock()
+	defer cli.lock.Unlock()
+	return cli.nextGetOperationStatus
+}
+
+func (cli *FakeConfigAgentClient) SetAsyncPhysicalBackup(async bool) {
+	cli.lock.Lock()
+	defer cli.lock.Unlock()
+	cli.asyncPhysicalBackup = async
+}
+
+func (cli *FakeConfigAgentClient) SetAsyncPhysicalRestore(async bool) {
+	cli.lock.Lock()
+	defer cli.lock.Unlock()
+	cli.asyncPhysicalRestore = async
 }


### PR DESCRIPTION
tested: bazel test --test_output=errors--test_tag_filters="-integration" //...--@io_bazel_rules_go//go/config:race