### PR TITLE
Add permissions for leases.coordination.k8s.io

### DIFF
--- a/oracle/config/rbac/role.yaml
+++ b/oracle/config/rbac/role.yaml
@@ -119,6 +119,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - ""
   resources:
   - services

--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -68,6 +68,7 @@ type InstanceReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=list;watch;get;patch;create
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 
 // +kubebuilder:rbac:groups=oracle.db.anthosapis.com,resources=databases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oracle.db.anthosapis.com,resources=databases/status,verbs=get;update;patch

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -2327,6 +2327,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - ""
   resources:
   - services


### PR DESCRIPTION
This fixes a crash loop when starting up the operator with error:
```
error retrieving resource lock operator-system/controller-leader-election-helper: leases.coordination.k8s.io "controller-leader-election-helper" is forbidden: User "system:serviceaccount:operator-system:default" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "operator-system"
```