### PR TITLE
[PE] Integration tests: do not use logf.Logr

### DIFF
--- a/oracle/controllers/inttest/parameterupdatetest/BUILD.bazel
+++ b/oracle/controllers/inttest/parameterupdatetest/BUILD.bazel
@@ -17,8 +17,6 @@ ginkgo_test(
         "@com_github_onsi_gomega//:gomega",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_client_go//plugin/pkg/client/auth/gcp",
-        "@io_k8s_klog_v2//:klog",
-        "@io_k8s_klog_v2//klogr",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/log",
     ],

--- a/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
+++ b/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
@@ -24,8 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -33,14 +31,12 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
-	v1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers/testhelpers"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/k8s"
 )
 
 func TestParameterUpdate(t *testing.T) {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ParameterUpdate")
 }
@@ -54,9 +50,7 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("ParameterUpdate", func() {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
-	log := logf.Log
+	log := logf.FromContext(nil)
 	pod := "mydb-sts-0"
 	instanceName := "mydb"
 

--- a/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
+++ b/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Instance and Database provisioning", func() {
 	BackupTest := func(tc backupTestCase) {
 		Context(tc.contextTitle, func() {
 			It("Should create rman based backup successfully", func() {
-				log := logf.Log
+				log := logf.FromContext(nil)
 
 				By("By creating an instance")
 				instance := &v1alpha1.Instance{

--- a/oracle/controllers/inttest/snapbackuptest/snapshot_backup_test.go
+++ b/oracle/controllers/inttest/snapbackuptest/snapshot_backup_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Backup through snapshot", func() {
 
 	snapBackupTest := func(version string, edition string) {
 		It("Should create snapshot based backup then restore to instance successfully", func() {
-			log := logf.Log
+			log := logf.FromContext(nil)
 
 			By("By creating a instance")
 			testhelpers.CreateSimpleInstance(k8sEnv, instanceName, version, edition)

--- a/oracle/controllers/inttest/usertest/BUILD.bazel
+++ b/oracle/controllers/inttest/usertest/BUILD.bazel
@@ -18,8 +18,6 @@ ginkgo_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_client_go//plugin/pkg/client/auth/gcp",
         "@io_k8s_client_go//util/retry",
-        "@io_k8s_klog_v2//:klog",
-        "@io_k8s_klog_v2//klogr",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/log",
     ],

--- a/oracle/controllers/inttest/usertest/user_test.go
+++ b/oracle/controllers/inttest/usertest/user_test.go
@@ -29,8 +29,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// Enable GCP auth for k8s client
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
@@ -39,8 +37,6 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	klog.SetOutput(GinkgoWriter)
-	logf.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "User operations")
 }
@@ -66,7 +62,7 @@ var (
 		"scott":      "tiger1",
 		"proberuser": "proberpassword1",
 	}
-	log = logf.Log
+	log = logf.FromContext(nil)
 )
 
 // Initial setup before test suite.
@@ -247,7 +243,7 @@ var _ = Describe("User operations", func() {
 					Message: "",
 				}, metav1.ConditionTrue)
 				if cond != nil && syncUserCompleted {
-					logf.Log.Info("PDB", "state", cond.Reason, "SyncComplete", syncUserCompleted)
+					log.Info("PDB", "state", cond.Reason, "SyncComplete", syncUserCompleted)
 					return cond.Status
 				}
 				return metav1.ConditionUnknown


### PR DESCRIPTION
[PE] Integration tests: do not use logf.Logr but use logf.FromContext(nil) instead.

This way we will see files and lines in logging output instead of 'deleg.go'

