### PR TITLE
[PE] Fix RMAN control file snapshot location

### DIFF
--- a/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
+++ b/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
@@ -295,6 +295,13 @@ var _ = Describe("Instance and Database provisioning", func() {
 			}
 			BackupTest(testCase)
 		})
+		Context("Oracle 19.3 EE", func() {
+			testCase.instanceSpec.Version = "19.3"
+			testCase.instanceSpec.Images = map[string]string{
+				"service": testhelpers.TestImageForVersion("19.3", "EE", ""),
+			}
+			BackupTest(testCase)
+		})
 	})
 })
 


### PR DESCRIPTION
Change the location of RMAN control file snapshot from
the container image filesystem to the data disk (<backupDir>/snapcf_<CDB>.f)
The default location is '/u01/app/oracle/product/<VERSION>/db/dbs/snapcf_<CDB>.f'
and it causes flaky behavior (ORA-00246) in Oracle 19.3

Add back Oracle 19 RMAN backup integration tests.

