### PR TITLE
Refactor snapshot in backup controller.

### DIFF
--- a/common/pkg/utils/BUILD.bazel
+++ b/common/pkg/utils/BUILD.bazel
@@ -5,7 +5,14 @@ go_library(
     srcs = ["utils.go"],
     importpath = "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/pkg/utils",
     visibility = ["//visibility:public"],
-    deps = ["//common/api/v1alpha1"],
+    deps = [
+        "//common/api/v1alpha1",
+        "@com_github_kubernetes_csi_external_snapshotter_v2//pkg/apis/volumesnapshot/v1beta1",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
 )
 
 filegroup(

--- a/common/pkg/utils/utils.go
+++ b/common/pkg/utils/utils.go
@@ -16,9 +16,16 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DiskSpaceTotal is a helper function to calculate the total amount
@@ -38,4 +45,44 @@ func DiskSpaceTotal(inst commonv1alpha1.Instance) (int64, error) {
 	}
 
 	return total, nil
+}
+
+// SnapshotDisks takes a snapshot of each disk as provided in diskSpecs. Ownership of the snapshots are granted to owner object.
+// getPvcSnapshotName is a function that, given a DiskSpec, returns the full PVC name, snapshot name, and volumeSnapshotClassName of that disk.
+// Taking snapshots here is best-effort only: it will returns errors even if only 1 disk failed the snapshot, and upon retry it will try to take snapshot of all disks again.
+func SnapshotDisks(ctx context.Context, diskSpecs []commonv1alpha1.DiskSpec, owner metav1.Object, c client.Client, scheme *runtime.Scheme,
+	getPvcSnapshotName func(commonv1alpha1.DiskSpec) (string, string, string), applyOpts []client.PatchOption) error {
+	for _, diskSpec := range diskSpecs {
+
+		fullPVCName, snapshotName, vsc := getPvcSnapshotName(diskSpec)
+		snap, err := newSnapshot(owner, scheme, fullPVCName, snapshotName, vsc)
+		if err != nil {
+			return err
+		}
+
+		if err := c.Patch(ctx, snap, client.Apply, applyOpts...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newSnapshot returns the snapshot for the given pv and set owner to own that snapshot.
+func newSnapshot(owner v1.Object, scheme *runtime.Scheme, pvcName, snapName, volumeSnapshotClassName string) (*snapv1.VolumeSnapshot, error) {
+
+	snapshot := &snapv1.VolumeSnapshot{
+		TypeMeta:   metav1.TypeMeta{APIVersion: snapv1.SchemeGroupVersion.String(), Kind: "VolumeSnapshot"},
+		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: owner.GetNamespace(), Labels: map[string]string{"snap": snapName}},
+		Spec: snapv1.VolumeSnapshotSpec{
+			Source:                  snapv1.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
+			VolumeSnapshotClassName: func() *string { s := string(volumeSnapshotClassName); return &s }(),
+		},
+	}
+
+	// Set the owner resource to own the VolumeSnapshot resource.
+	if err := ctrl.SetControllerReference(owner, snapshot, scheme); err != nil {
+		return snapshot, err
+	}
+
+	return snapshot, nil
 }

--- a/oracle/controllers/backupcontroller/BUILD.bazel
+++ b/oracle/controllers/backupcontroller/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common/api/v1alpha1",
+        "//common/pkg/utils",
         "//oracle/api/v1alpha1",
         "//oracle/controllers",
         "//oracle/pkg/agents/config_agent/protos",

--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -728,25 +728,6 @@ func NewPodTemplate(sp StsParams, cdbName, DBDomain string) corev1.PodTemplateSp
 	}
 }
 
-// NewSnapshot returns the snapshot for the given pv.
-func NewSnapshot(backup *v1alpha1.Backup, scheme *runtime.Scheme, pvcName, snapName, volumeSnapshotClassName string) (*snapv1.VolumeSnapshot, error) {
-	snap := &snapv1.VolumeSnapshot{
-		TypeMeta:   metav1.TypeMeta{APIVersion: snapv1.SchemeGroupVersion.String(), Kind: "VolumeSnapshot"},
-		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: backup.Namespace, Labels: map[string]string{"snap": snapName}},
-		Spec: snapv1.VolumeSnapshotSpec{
-			Source:                  snapv1.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
-			VolumeSnapshotClassName: func() *string { s := string(volumeSnapshotClassName); return &s }(),
-		},
-	}
-
-	// Set the Instance resource to own the VolumeSnapshot resource.
-	if err := ctrl.SetControllerReference(backup, snap, scheme); err != nil {
-		return snap, err
-	}
-
-	return snap, nil
-}
-
 // NewSnapshot returns the snapshot for the given instance and pv.
 func NewSnapshotInst(inst *v1alpha1.Instance, scheme *runtime.Scheme, pvcName, snapName, volumeSnapshotClassName string) (*snapv1.VolumeSnapshot, error) {
 	snap := &snapv1.VolumeSnapshot{


### PR DESCRIPTION
* Move the snapshot logic to `utils.SnapshotDisks`
* Caller needs to supply a mapping between disk and PVC name / snapshot name as these logics are not generic enough to be in a common package.

Change-Id: I189f50f81a65387a340794eba2d848858f6c6da1