### PR TITLE
Enable Unified Auditing during bootstrapping

### DIFF
--- a/oracle/build/BUILD.bazel
+++ b/oracle/build/BUILD.bazel
@@ -21,6 +21,7 @@ container_image(
     directory = "agent_repo",
     files = [
         "//oracle/cmd/dbdaemon",
+        "//oracle/cmd/dbdaemon:init_dbdaemon_files",
         "//oracle/cmd/dbdaemon_proxy",
         "//oracle/cmd/init_oracle",
         "//oracle/cmd/init_oracle:init_oracle_files",

--- a/oracle/build/dbinit/Dockerfile
+++ b/oracle/build/dbinit/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder /build/dbdaemon \
 /build/init_oracle \
 /build/oracle/cmd/init_oracle/init_oracle.sh \
 /build/oracle/cmd/init_oracle/stop_oracle.sh \
+/build/oracle/cmd/dbdaemon/init_dbdaemon.sh \
 /build/oracle/pkg/database/provision/bootstrap-database-initfile.template \
 /build/oracle/pkg/database/provision/bootstrap-database-initfile-oracle-xe.template \
 /build/oracle/pkg/database/provision/bootstrap-database-crcf.template \

--- a/oracle/cmd/dbdaemon/BUILD.bazel
+++ b/oracle/cmd/dbdaemon/BUILD.bazel
@@ -21,6 +21,14 @@ go_binary(
 )
 
 filegroup(
+    name = "init_dbdaemon_files",
+    srcs = [
+        "init_dbdaemon.sh",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],

--- a/oracle/cmd/dbdaemon/init_dbdaemon.sh
+++ b/oracle/cmd/dbdaemon/init_dbdaemon.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+SCRIPTS_DIR="/agents"
+
+echo "$(date +%Y-%m-%d.%H:%M:%S) Enabling Unified Auditing in the dbdaemon container..."  >> "${SCRIPTS_DIR}/init_dbdaemon.log"
+make -C $ORACLE_HOME/rdbms/lib -f ins_rdbms.mk uniaud_on ioracle ORACLE_HOME="${ORACLE_HOME}" >> "${SCRIPTS_DIR}/init_dbdaemon.log"
+rc=$?
+if (( ${rc} != 0 )); then
+  echo "$(date +%Y-%m-%d.%H:%M:%S) Error occurred while attempting to enable Unified Auditing in the dbdaemon container: ${rc}"  >> "${SCRIPTS_DIR}/init_dbdaemon.log"
+fi
+
+${SCRIPTS_DIR}/dbdaemon --cdb_name="$1"

--- a/oracle/cmd/init_oracle/init_oracle.sh
+++ b/oracle/cmd/init_oracle/init_oracle.sh
@@ -39,6 +39,13 @@ trap term_handler SIGTERM
 trap kill_handler SIGKILL
 trap int_handler SIGINT
 
+echo "$(date +%Y-%m-%d.%H:%M:%S) Enabling Unified Auditing in the oracledb container..."  >> "${SCRIPTS_DIR}/init_oracle.log"
+make -C $ORACLE_HOME/rdbms/lib -f ins_rdbms.mk uniaud_on ioracle ORACLE_HOME="${ORACLE_HOME}" >> "${SCRIPTS_DIR}/init_oracle.log"
+rc=$?
+if (( ${rc} != 0 )); then
+  echo "$(date +%Y-%m-%d.%H:%M:%S) Error occurred while attempting to enable Unified Auditing in the oracledb container: ${rc}"  >> "${SCRIPTS_DIR}/init_oracle.log"
+fi
+
 ${SCRIPTS_DIR}/dbdaemon_proxy --cdb_name="$1" &
 childPID=$!
 echo "$(date +%Y-%m-%d.%H:%M:%S) Initializing database daemon proxy with PID $childPID"  >> "${SCRIPTS_DIR}/init_oracle.log"

--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -611,8 +611,8 @@ func NewPodTemplate(sp StsParams, cdbName, DBDomain string) corev1.PodTemplateSp
 		{
 			Name:    "dbdaemon",
 			Image:   sp.Images["service"],
-			Command: []string{"/agents/dbdaemon"},
-			Args:    []string{fmt.Sprintf("--cdb_name=%s", cdbName)},
+			Command: []string{fmt.Sprintf("%s/init_dbdaemon.sh", scriptDir)},
+			Args:    []string{cdbName},
 			Ports: []corev1.ContainerPort{
 				{Name: "dbdaemon", Protocol: "TCP", ContainerPort: consts.DefaultDBDaemonPort},
 			},


### PR DESCRIPTION
El Carro requires Unified Auditing (UA) to be enabled for proper functioning, reason why we enable it in install-oracle.sh. Unfortunately, OCR images do not come with UA enabled. Since Enabling UA is an idempotent operation, this change will be backward compatible with DB images previously generated using El Carro image build scripts.

Change-Id: Ib692cbc83142670276ec2c8345f13b27bef3834e