### PR TITLE
Improve test env cleanup

### DIFF
--- a/oracle/controllers/testhelpers/envtest.go
+++ b/oracle/controllers/testhelpers/envtest.go
@@ -283,7 +283,10 @@ func cleanupK8Cluster(namespace string, k8sClient client.Client) {
 		},
 	}
 	if k8sClient != nil {
-		k8sClient.Delete(context.Background(), nsObj)
+		policy := metav1.DeletePropagationForeground
+		k8sClient.Delete(context.Background(), nsObj, &client.DeleteOptions{
+			PropagationPolicy: &policy,
+		})
 	}
 	os.Remove(fmt.Sprintf("/tmp/.kubectl/config-%v", namespace))
 }

--- a/oracle/scripts/integration_test_cluster/delete_integration_test_cluster.sh
+++ b/oracle/scripts/integration_test_cluster/delete_integration_test_cluster.sh
@@ -24,6 +24,10 @@ set -o pipefail
 [[ -z "$PROW_CLUSTER_ZONE" ]] && { echo "PROW_CLUSTER_ZONE envvar was not set. Did you try to test without make?" ; exit 1; }
 [[ -z "$PROW_PROJECT" ]] && { echo "PROW_PROJECT envvar was not set. Did you try to test without make?" ; exit 1; }
 
+# Add a grace period before test cluster deletion, so that kubernetes controllers
+# have chance to cleanup related resources.
+sleep 100
+
 echo "Deleting cluster '${PROW_CLUSTER}' (this may take a few minutes)..."
 
 set -x #echo on


### PR DESCRIPTION
* Add a grace period before test cluster deletion.
* Add DeletePropagationForeground for namespace deletion.

Change-Id: I34710476c6196d66e16ec6ebc7a4e90375c4a7f2