### PR TITLE
Cleanup stale forwarding rules and target pools

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -199,7 +199,7 @@ operator-checks: prepare-prow
 # Prow presubmit job entry point: operator-presubmit
 operator-presubmit: prepare-prow
 	$(MAKE) -j8 buildah-push-all
-	# Remove stale clusters from the project
+	# Remove stale resources from the project
 	scripts/integration_test_cluster/cleanup_integration_test_clusters.sh
 	# Create a new GKE cluster for int tests
 	scripts/integration_test_cluster/create_integration_test_cluster.sh


### PR DESCRIPTION
According to GCP docs (https://cloud.google.com/kubernetes-engine/docs/how-to/deleting-a-cluster#:~:text=The%20following%20resources%20are%20not%20deleted), forwarding rules/load balancers are not deleted after a cluster is deleted. They must be cleaned up manually. Stale rules in our test infra have accumulated for months and held up quota leading to repeated test failures due to quota exhaustion.

Change-Id: I7999c0dbe54d86371d6068b46b70e0d0bb624261