### PR TITLE
Fix uid:pid in loggingsidecar image

### DIFF
--- a/oracle/build/BUILD.bazel
+++ b/oracle/build/BUILD.bazel
@@ -82,6 +82,8 @@ container_image(
         "//oracle/cmd/logging",
     ],
     symlinks = {"/logging_main": "/logging"},
+    user = "54321:54322",  # oracle:dba,
+    workdir = "/home/oracle",
 )
 
 container_push(


### PR DESCRIPTION
Create loggingsidecar image with uid/gid "54321:54322" (oracle:dba) and
workDir=/home/oracle
instead of nonroot:nonroot, /home/nonroot. This should fix EKS issues with this image.
