### PR TITLE
Minor fix to check createServices error to avoid panic

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -357,6 +357,9 @@ func (r *InstanceReconciler) Reconcile(_ context.Context, req ctrl.Request) (_ c
 
 	// Create LB/NodePort Services if needed.
 	svcLB, svc, err := r.createServices(ctx, inst, services, applyOpts)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if iReadyCond == nil {
 		iReadyCond = k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionFalse, k8s.CreateInProgress, "")


### PR DESCRIPTION
It is possible that createServices returns error and calls to get svcURL
fails. Add error check to avoid a panic when svc is null.

Change-Id: Icf566b80566ad2e885688b105354fb6fa6bfacf8