### PR TITLE
Minor fix to createServices

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -754,11 +754,11 @@ func (r *InstanceReconciler) createServices(ctx context.Context, inst v1alpha1.I
 	for _, s := range services {
 		svc, err := controllers.NewSvc(&inst, r.Scheme, s)
 		if err != nil {
-			return nil, nil, nil
+			return nil, nil, err
 		}
 
 		if err := r.Patch(ctx, svc, client.Apply, applyOpts...); err != nil {
-			return nil, nil, nil
+			return nil, nil, err
 		}
 
 		if s == "lb" {


### PR DESCRIPTION
Fix createServices to return err if error occurred. This fixes the
controllers.SvcURL panic in functional test.

Run instancecontroller_test 30 times and no controllers.SvcURL panic
occurs.

Change-Id: I73792446d5853888490fbc6b5bac5d510a7682a6