### PR TITLE
Fix flaky instance test with unseeded OCR image

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -76,9 +76,9 @@ type InstanceReconciler struct {
 const (
 	physicalRestore                       = "PhysicalRestore"
 	InstanceProvisionTimeoutSeeded        = 20 * time.Minute
-	InstanceProvisionTimeoutUnseeded      = 50 * time.Minute // 50 minutes because it can take 40+ minutes for unseeded CDB creations
+	InstanceProvisionTimeoutUnseeded      = 55 * time.Minute // 55 minutes because it can take 40+ minutes for unseeded CDB creations
 	CreateDatabaseInstanceTimeoutSeeded   = 20 * time.Minute
-	CreateDatabaseInstanceTimeoutUnSeeded = 50 * time.Minute // 50 minutes because it can take 40+ minutes for unseeded CDB creations
+	CreateDatabaseInstanceTimeoutUnSeeded = 55 * time.Minute // 55 minutes because it can take 40+ minutes for unseeded CDB creations
 	dateFormat                            = "20060102"
 )
 

--- a/oracle/controllers/inttest/instancetest/instance_test.go
+++ b/oracle/controllers/inttest/instancetest/instance_test.go
@@ -109,11 +109,11 @@ var _ = Describe("Instance and Database provisioning", func() {
 			createdInstance := &v1alpha1.Instance{}
 			instKey := client.ObjectKey{Namespace: namespace, Name: instanceName}
 
-			insTimeout := instancecontroller.InstanceProvisionTimeoutUnseeded
-			dbTimeout := instancecontroller.CreateDatabaseInstanceTimeoutUnSeeded
-			if isImageSeeded {
-				insTimeout = instancecontroller.InstanceProvisionTimeoutSeeded
-				dbTimeout = instancecontroller.CreateDatabaseInstanceTimeoutSeeded
+			insTimeout := instancecontroller.InstanceProvisionTimeoutSeeded
+			dbTimeout := instancecontroller.CreateDatabaseInstanceTimeoutSeeded
+			if !isImageSeeded {
+				insTimeout = instancecontroller.InstanceProvisionTimeoutUnseeded
+				dbTimeout = instancecontroller.CreateDatabaseInstanceTimeoutUnSeeded
 			}
 
 			By("By checking that Instance is created")


### PR DESCRIPTION
Instance provision test with 19.3 Unseeded OCR image is flaky. Failure
are due to db provision timeout. And successful runs took more than
3000s, increate the timeout to reduce flakiness.

Change-Id: Ie62ae3cfb556c16f85239a16dcce63825f96e2cf