### PR TITLE
Increase bazel job count to match cluster node count

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -102,7 +102,7 @@ test:
 	bazel \
 		--bazelrc=controllers/inttest/.bazelrc \
 		test \
- 		--jobs=8 \
+ 		--jobs=10 \
  		--test_tag_filters="integration" \
  		... \
 		--test_output=errors \


### PR DESCRIPTION
The node count for integration test clusters should always be >= bazel job count + 2

Change-Id: I32626a4dd636f5c60659bcb179f8fa0e5b2c681d