### PR TITLE
Support static IP address

### DIFF
--- a/oracle/api/v1alpha1/instance_types.go
+++ b/oracle/api/v1alpha1/instance_types.go
@@ -163,6 +163,11 @@ type DBNetworkServiceOptionsGCP struct {
 	// +kubebuilder:validation:Enum="";Internal;External
 	// +optional
 	LoadBalancerType string `json:"loadBalancerType,omitempty"`
+
+	// LoadBalancerIP is a static IP address, see
+	// https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+	// +optional
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 }
 
 // InstanceStatus defines the observed state of Instance.

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
@@ -153,6 +153,9 @@ spec:
                     description: GCP contains Google Cloud specific attributes of
                       Service configuration.
                     properties:
+                      loadBalancerIP:
+                        description: LoadBalancerIP is a static IP address, see https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType let's define a type of load
                           balancer, see https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer

--- a/oracle/config/samples/v1alpha1_instance_gcp_lb.yaml
+++ b/oracle/config/samples/v1alpha1_instance_gcp_lb.yaml
@@ -29,6 +29,13 @@ spec:
   dbNetworkServiceOptions:
     gcp:
       loadBalancerType: Internal
+# Uncomment this section to specify a static load balancer IP address
+#      # Note the IP address type, Internal or External, should match the loadBalancerType. See
+#      # https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address
+#      # https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+#      # on how to reserve static IP addresses
+#      loadBalancerIP: ${STATIC_IP_ADDRESS}
+
 # Uncomment this section to trigger a restore.
 #  restore:
 #    backupType: "Snapshot" #(or "Physical")

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -1833,6 +1833,9 @@ spec:
                     description: GCP contains Google Cloud specific attributes of
                       Service configuration.
                     properties:
+                      loadBalancerIP:
+                        description: LoadBalancerIP is a static IP address, see https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType let's define a type of load
                           balancer, see https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer


### PR DESCRIPTION
For DR restore, it is desired to keep the load balancer IP address the same
for the old and new instances. In GCP this can be achieved by reserving
a static IP address. This cl adds an optional field loadBalancerIP to
DBNetworkServiceOptionalsGCP struct. If specified, service would be
created with the IP address provided.

Change-Id: Iee45bd6078424c7b8a9f9b74593a293e81c6350c