### PR TITLE
Reduce integration test flakiness

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -74,7 +74,7 @@ const (
 	physicalRestore                      = "PhysicalRestore"
 	InstanceReadyTimeout                 = 20 * time.Minute
 	DatabaseInstanceReadyTimeoutSeeded   = 20 * time.Minute
-	DatabaseInstanceReadyTimeoutUnseeded = 55 * time.Minute // 55 minutes because it can take 40+ minutes for unseeded CDB creations
+	DatabaseInstanceReadyTimeoutUnseeded = 60 * time.Minute // 60 minutes because it can take 50+ minutes to create an unseeded CDB
 	dateFormat                           = "20060102"
 )
 

--- a/oracle/controllers/inttest/instancetest/instance_test.go
+++ b/oracle/controllers/inttest/instancetest/instance_test.go
@@ -114,6 +114,7 @@ var _ = Describe("Instance and Database provisioning", func() {
 			if !isImageSeeded {
 				dbTimeout = instancecontroller.DatabaseInstanceReadyTimeoutUnseeded
 			}
+			dbTimeout += 5 * time.Minute // Add some buffer time given that this test runs in a different process space than the instance
 
 			By("By checking that Instance is created")
 			// Wait until the instance is "Ready" (requires 5+ minutes to download image)

--- a/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
+++ b/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
@@ -145,10 +145,10 @@ var _ = Describe("Instance and Database provisioning", func() {
 				)
 
 				// Wait until the instance is "Ready"
-				testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.RestoreComplete, 10*time.Minute)
+				testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.RestoreComplete, 20*time.Minute)
 
 				// Check databases are "Ready"
-				testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.DatabaseInstanceReady, metav1.ConditionTrue, k8s.CreateComplete, 30*time.Second)
+				testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.DatabaseInstanceReady, metav1.ConditionTrue, k8s.CreateComplete, 10*time.Minute)
 
 				testhelpers.VerifySimpleData(k8sEnv)
 			})


### PR DESCRIPTION
Increase timeout for physical backup restore because Oracle 19c RMAN backup and restore operations can take considerably longer than those of 12c

Increase DB creation timeout for unseeded images because a 19c CDB can take much longer to create than a 12c one.

Change-Id: Ie1b1c0abdd5a0f7553639d0e9c68b754e5c708bb