### PR TITLE
Fixup some scripts

### DIFF
--- a/oracle/build/dbimage/image_build.sh
+++ b/oracle/build/dbimage/image_build.sh
@@ -40,13 +40,13 @@ sanity_check_params() {
     if [ -z "${CDB_NAME}" ]; then
       CDB_NAME="GCLOUD"
     fi
-    db_name_len=`expr length "${CDB_NAME}"`
+    db_name_len="${#CDB_NAME}"
     if [[ "${db_name_len}" -le 0 || "${db_name_len}" -gt 8 ]]; then
       echo "CDB_NAME should be less than or equal to 8 characters"
       usage
     fi
   else
-    db_name_len=`expr length "${CDB_NAME}"`
+    db_name_len="${#CDB_NAME}"
     if [[ "${db_name_len}" -gt 0 ]]; then
       echo "CDB_NAME is set but CREATE_CDB is not"
       usage


### PR DESCRIPTION
Unifies redeploy with the `make env` parameters so you dont need pass
parameters if you have them set.

Fixes #4 by removing `expr length` and using bash parameter substitution
equivalents.

Change-Id: If93d7ca380e0891089eaa89ea3bf2e41ecdd6316