### PR TITLE
Reduce Oracle DB image size

### DIFF
--- a/oracle/build/dbimage/Dockerfile
+++ b/oracle/build/dbimage/Dockerfile
@@ -19,9 +19,19 @@
 # ARG BASE_IMAGE=oraclelinux:7-slim
 
 FROM docker.io/oraclelinux:7-slim as base
+
 ARG DB_VERSION
 ARG ORACLE_HOME
 ARG ORACLE_BASE
+ARG CREATE_CDB
+ARG CDB_NAME
+ENV STAGE_DIR=/tmp/stage/
+COPY oracle-preinstall.sh $STAGE_DIR
+RUN /bin/bash -c $STAGE_DIR/oracle-preinstall.sh
+
+FROM base as installer
+
+ARG DB_VERSION
 ARG CREATE_CDB
 ARG CDB_NAME
 ARG CHARACTER_SET
@@ -29,28 +39,41 @@ ARG MEM_PCT
 ARG EDITION
 ARG PATCH_VERSION
 ARG INSTALL_SCRIPT
-ENV STAGE_DIR=/tmp/stage/
 
-RUN mkdir $STAGE_DIR && chmod ug+w $STAGE_DIR
 ADD ./* $STAGE_DIR
 RUN /bin/bash -c \
-    'if [ "$DB_VERSION" = "18c" ] && [ "$EDITION" = "xe" ]; then \
+    'if [ "${DB_VERSION}" = "18c" ] && [ "${EDITION}" = "xe" ]; then \
       export INSTALL_SCRIPT=install-oracle-18c-xe.sh; \
       chmod +x $STAGE_DIR$INSTALL_SCRIPT; \
-      $STAGE_DIR/$INSTALL_SCRIPT $CDB_NAME $CHARACTER_SET && \
+      $STAGE_DIR/$INSTALL_SCRIPT "${CDB_NAME}" "${CHARACTER_SET}" && \
       rm -rf $INSTALL_SCRIPT && \
       rm -rf $STAGE_DIR; \
     else \
       export INSTALL_SCRIPT=install-oracle.sh; \
       chmod +x $STAGE_DIR$INSTALL_SCRIPT; \
-      $STAGE_DIR/$INSTALL_SCRIPT $DB_VERSION $EDITION $CREATE_CDB $CDB_NAME $CHARACTER_SET $MEM_PCT $PATCH_VERSION && \
+      $STAGE_DIR/$INSTALL_SCRIPT "${DB_VERSION}" "${EDITION}" "${CREATE_CDB}" "${CDB_NAME}" "${CHARACTER_SET}" "${MEM_PCT}" "${PATCH_VERSION}" && \
       rm -rf $INSTALL_SCRIPT && \
       rm -rf $STAGE_DIR; \
     fi'
 
+FROM base as database_image
+
+ARG ORACLE_HOME
+ARG ORACLE_BASE
+ARG CDB_NAME
+
 ENV ORACLE_HOME=$ORACLE_HOME
 ENV ORACLE_BASE=$ORACLE_BASE
+ENV ORACLE_SID=$CDB_NAME
 ENV LD_LIBRARY_PATH=$ORACLE_HOME/lib:/usr/lib
+
+USER oracle
+COPY --chown=oracle:dba --from=installer $ORACLE_BASE $ORACLE_BASE
+COPY --chown=oracle:dba --from=installer /etc/oratab /etc/oratab
+COPY --chown=oracle:dba --from=installer /etc/oraInst.loc /etc/oraInst.loc
+
+USER root
+RUN $ORACLE_HOME/root.sh && rm $STAGE_DIR/oracle-preinstall.sh
 
 VOLUME ["/u02", "/u03"]
 # TODO: make the port number configurable

--- a/oracle/build/dbimage/cloudbuild-18c-xe.yaml
+++ b/oracle/build/dbimage/cloudbuild-18c-xe.yaml
@@ -23,6 +23,7 @@ steps:
   - '--no-cache'
   - '--build-arg=DB_VERSION=18c'
   - '--build-arg=ORACLE_HOME=$_ORACLE_HOME'
+  - '--build-arg=CREATE_CDB=true'
   - '--build-arg=ORACLE_BASE=$_ORACLE_BASE'
   - '--build-arg=CDB_NAME=$_CDB_NAME'
   - '--build-arg=CHARACTER_SET=$_CHARACTER_SET'

--- a/oracle/build/dbimage/image_build.sh
+++ b/oracle/build/dbimage/image_build.sh
@@ -238,7 +238,7 @@ execute_command() {
     IMAGE_NAME_SUFFIX="seeded-${IMAGE_NAME_SUFFIX}"
   else
     IMAGE_NAME_SUFFIX="unseeded"
-    CDB_NAME="${DUMMY_VALUE}"
+    CDB_NAME=""
   fi
 
   if [ "${DB_VERSION}" == "${ORACLE_18}" ] && [ "${EDITION}" == "xe" ]; then
@@ -254,7 +254,7 @@ execute_command() {
   fi
 
   if [ "${LOCAL_BUILD}" == true ]; then
-    BUILD_CMD=$(echo docker build --no-cache --build-arg=DB_VERSION=${DB_VERSION} --build-arg=ORACLE_HOME=${ORACLE_HOME} --build-arg=ORACLE_BASE=${ORACLE_BASE} --build-arg=CREATE_CDB=${CREATE_CDB} --build-arg=CDB_NAME=${CDB_NAME} --build-arg=CHARACTER_SET=${CHARACTER_SET} --build-arg=MEM_PCT=${MEM_PCT} --build-arg=EDITION=${EDITION} --build-arg=PATCH_VERSION=${PATCH_VERSION} --tag=$TAG .)
+    BUILD_CMD=$(echo docker build --no-cache --build-arg=DB_VERSION="${DB_VERSION}" --build-arg=ORACLE_HOME="${ORACLE_HOME}" --build-arg=ORACLE_BASE="${ORACLE_BASE}" --build-arg=CREATE_CDB="${CREATE_CDB}" --build-arg=CDB_NAME="${CDB_NAME}" --build-arg=CHARACTER_SET="${CHARACTER_SET}" --build-arg=MEM_PCT="${MEM_PCT}" --build-arg=EDITION="${EDITION}" --build-arg=PATCH_VERSION="${PATCH_VERSION}" --tag="$TAG" .)
   else
     if [ "${DB_VERSION}" == "${ORACLE_18}" ]; then
       BUILD_CMD=$(echo gcloud builds submit --project=${PROJECT_ID} --config=cloudbuild-18c-xe.yaml --substitutions=_ORACLE_HOME="${ORACLE_HOME}",_ORACLE_BASE="${ORACLE_BASE}",_CDB_NAME="${CDB_NAME}",_CHARACTER_SET="${CHARACTER_SET}",_TAG="${TAG}")

--- a/oracle/build/dbimage/install-oracle-18c-xe.sh
+++ b/oracle/build/dbimage/install-oracle-18c-xe.sh
@@ -26,44 +26,8 @@ readonly GROUP="dba"
 readonly OHOME="/opt/oracle/product/18c/dbhomeXE"
 readonly DB_VERSION="18c"
 
-setup_directories() {
-  mkdir -p "/home/${USER}"
-}
-
-install_debug_utilities() {
-  yum install -y shadow-utils openssl sudo
-  yum install -y nmap-ncat.x86_64
-  yum install -y strace.x86_64
-  yum install -y net-tools.x86_64
-  yum install -y lsof.x86_64
-}
-
-write_pam_files() {
-  echo "#%PAM-1.0
-auth       include      system-auth
-account    include      system-auth
-password   include      system-auth
-" >/etc/pam.d/sudo
-
-    echo "#%PAM-1.0
-auth		sufficient	pam_rootok.so
-auth		substack	system-auth
-auth		include		postlogin
-account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
-account		include		system-auth
-password	include		system-auth
-session		include		postlogin
-session		optional	pam_xauth.so
-" >/etc/pam.d/su
-}
-
 set_environment() {
   export ORACLE_DOCKER_INSTALL=true
-  echo "export ORACLE_HOME=${OHOME}" >>"/home/oracle/${CDB_NAME}.env"
-  echo "export ORACLE_BASE=/opt/oracle" >>"/home/oracle/${CDB_NAME}.env"
-  echo "export ORACLE_SID=${CDB_NAME}" >>"/home/oracle/${CDB_NAME}.env"
-  echo "export PATH=${OHOME}/bin:${OHOME}/OPatch:/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" >>"/home/oracle/${CDB_NAME}.env"
-  echo "export LD_LIBRARY_PATH=${OHOME}/lib" >>"/home/oracle/${CDB_NAME}.env"
   source "/home/oracle/${CDB_NAME}.env"
 }
 
@@ -105,17 +69,8 @@ run_sql() {
   echo "${1}" | sudo -E -u oracle "${ORACLE_HOME}/bin/sqlplus" -S / as sysdba
 }
 
-create_metadata_file() {
-  echo "ORACLE_HOME=${OHOME}" >>"/home/oracle/.metadata"
-  echo "ORACLE_SID=${CDB_NAME}" >>"/home/oracle/.metadata"
-  echo "VERSION=${DB_VERSION}" >>"/home/oracle/.metadata"
-}
-
 main() {
   echo "Running Oracle 18c XE install script..."
-  install_debug_utilities
-  write_pam_files
-  setup_directories
   set_environment
   install_oracle
   write_oracle_config
@@ -123,7 +78,6 @@ main() {
   set_file_ownership
   delete_xe_pdb
   shutdown_oracle
-  create_metadata_file
   echo "Oracle 18c XE installation succeeded!"
 }
 

--- a/oracle/build/dbimage/oracle-preinstall.sh
+++ b/oracle/build/dbimage/oracle-preinstall.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -e
+set -u
+readonly ORACLE_12="12.2"
+readonly ORACLE_18="18c"
+readonly ORACLE_19="19.3"
+readonly USER='oracle'
+readonly GROUP='dba'
+
+install_packages() {
+  yum install -y shadow-utils openssl sudo
+  yum install -y nmap-ncat.x86_64
+  yum install -y strace.x86_64
+  yum install -y net-tools.x86_64
+  yum install -y lsof.x86_64
+  yum install -y "${PREINSTALL_RPM}"
+  echo "#%PAM-1.0
+auth       include      system-auth
+account    include      system-auth
+password   include      system-auth
+" >/etc/pam.d/sudo
+  if [[ "${DB_VERSION}" == "${ORACLE_18}" ]]; then
+        echo "#%PAM-1.0
+auth		sufficient	pam_rootok.so
+auth		substack	system-auth
+auth		include		postlogin
+account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
+account		include		system-auth
+password	include		system-auth
+session		include		postlogin
+session		optional	pam_xauth.so
+" >/etc/pam.d/su
+  fi
+}
+
+
+pick_pre_installer() {
+  if [[ "${DB_VERSION}" == "${ORACLE_12}" ]]; then
+    local -g PREINSTALL_RPM="oracle-database-server-12cR2-preinstall.x86_64"
+  elif [[ "${DB_VERSION}" == "${ORACLE_18}" ]]; then
+    local -g PREINSTALL_RPM="oracle-database-preinstall-18c.x86_64"
+  elif [[ "${DB_VERSION}" == "${ORACLE_19}" ]]; then
+    local -g PREINSTALL_RPM="oracle-database-preinstall-19c.x86_64"
+  else
+    echo "DB version ${DB_VERSION} not supported"
+    exit 1
+  fi
+}
+
+setup_directories() {
+  mkdir -p "${ORACLE_HOME}"
+  #use oinstall instead of dba to allow the script to work for 18c XE.
+  #This is harmless because we always revert ownership of $ORACLE_BASE to oracle:dba in the Dockerfile.
+  chown -R "${USER}:oinstall" "${ORACLE_BASE}"
+  chown -R "${USER}:${GROUP}" "/home/${USER}"
+}
+
+create_env_file() {
+  echo "export ORACLE_HOME=${ORACLE_HOME}" >>"/home/oracle/${CDB_NAME}.env"
+  echo "export ORACLE_BASE=${ORACLE_BASE}" >>"/home/oracle/${CDB_NAME}.env"
+  echo "export ORACLE_SID=${CDB_NAME}" >>"/home/oracle/${CDB_NAME}.env"
+  echo "export PATH=${ORACLE_HOME}/bin:${ORACLE_HOME}/OPatch:/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" >>"/home/oracle/${CDB_NAME}.env"
+  echo "export LD_LIBRARY_PATH=${ORACLE_HOME}/lib:/usr/lib" >>"/home/oracle/${CDB_NAME}.env"
+  chown "${USER}:${GROUP}" "/home/oracle/${CDB_NAME}.env"
+}
+
+pick_pre_installer
+install_packages
+setup_directories
+if [[ "${CREATE_CDB}" == true ]]; then
+  create_env_file
+fi


### PR DESCRIPTION
The docker image build will now take place in three docker stages. In a preliminary base stage, oracle-preinstall.sh is executed to prepare the OS for an oracle DB installation. In a subsequent stage, the actual database software is installed. In the final stage, the database installation is copied to a clone of the base stage leaving behind staging and installer files to create the final DB image.

The metadata file will no longer be part of El Carro DB images because it provides redundant information which can readily be obtained from environment variables. Further, OCR images do not come with a metadata file.

Change-Id: Idabc34898713358ab4f24e21c44e970b00d38113