### PR TITLE
Make last transition time sensitive to changes in reason field of con…

### DIFF
--- a/oracle/pkg/k8s/condition.go
+++ b/oracle/pkg/k8s/condition.go
@@ -114,11 +114,11 @@ func InstanceUpsertCondition(iStatus *v1alpha1.InstanceStatus, name string, stat
 func Upsert(conditions []v1.Condition, name string, status v1.ConditionStatus, reason, message string) []v1.Condition {
 
 	if cond := FindCondition(conditions, name); cond != nil {
-		if !ConditionStatusEquals(cond, status) { // LastTransitionTime refers to the time Status changes
+		if !ConditionStatusEquals(cond, status) || !ConditionReasonEquals(cond, reason) { // LastTransitionTime refers to the time Status changes
 			cond.Status = status
+			cond.Reason = reason
 			cond.LastTransitionTime = v1Now()
 		}
-		cond.Reason = reason
 		cond.Message = message
 		return conditions
 	}

--- a/oracle/pkg/k8s/condition_test.go
+++ b/oracle/pkg/k8s/condition_test.go
@@ -150,7 +150,7 @@ func TestInstanceUpsertCondition(t *testing.T) {
 				Type:               "OldCond",
 				Status:             v1.ConditionFalse,
 				Reason:             "NewReason",
-				LastTransitionTime: oldTime,
+				LastTransitionTime: newTime,
 			},
 			ExistingConds: []v1.Condition{
 				{
@@ -259,7 +259,7 @@ func TestUpsert(t *testing.T) {
 				Type:               "OldCond",
 				Status:             v1.ConditionFalse,
 				Reason:             "NewReason",
-				LastTransitionTime: oldTime,
+				LastTransitionTime: newTime,
 			},
 			ExistingConds: []v1.Condition{
 				{


### PR DESCRIPTION
…dition used for state transitions.

Summary: Our existing timeout based workflows is incorrectly using the cumulative time starting when the condition status changes (true <-> false) since the last transition time ignores the reason field used for state transitions. This change fixes it.

Change-Id: Ifad927cd98a7d3c315c3a718e4ad05ac0955ea02