### PR TITLE
Create image type flag file during startup of oracledb container

### DIFF
--- a/oracle/cmd/dbdaemon_proxy/BUILD.bazel
+++ b/oracle/cmd/dbdaemon_proxy/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//oracle/pkg/agents/consts",
         "//oracle/pkg/agents/oracle",
         "//oracle/pkg/database/dbdaemonproxy",
+        "//oracle/pkg/database/provision",
         "@io_k8s_klog_v2//:klog",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/oracle/pkg/agents/consts/consts.go
+++ b/oracle/pkg/agents/consts/consts.go
@@ -105,6 +105,12 @@ var (
 	// this is placed on the PD storage so that on recreate, the bootstrap doesnt re-run.
 	ProvisioningDoneFile = "/u02/app/oracle/provisioning_successful"
 
+	// SeededImageFile indicates that a CDB exists in the image or one of the volumes mounted to it
+	SeededImageFile = "/tmp/seeded_image"
+
+	// UnseededImageFile indicates that a CDB does not exist in the image, nor in any volume mounted to it
+	UnseededImageFile = "/tmp/unseeded_image"
+
 	// SECURE is the name of the secure tns listener
 	SECURE = "SECURE"
 	// ListenerNames is the list of listeners


### PR DESCRIPTION
There's a need to store the type of a database image during instance creation/bootstrapping. That information could be stored in the data plane or the control plane. During provisioning of a new instance, shortly after a database is bootstrapped, our current workflows do not allow us to determine whether an image was originally seeded or not because FetchServiceImageMetaData returns the name of the CDB that has just been created, sometimes leading the control plane to use the wrong bootstrapping mode and making integration tests flake. The introduction of the seeded/unseeded image type file flag allows us to confidently assert during instance provisioning whether an image was originally seeded or not. After provisioning, all images/instances are effectively considered seeded.

Change-Id: Iccba27ae8f6d504e2bdfc9519264c0304b9b3ca8