### PR TITLE
Enhance detection of CDB

### DIFF
--- a/oracle/pkg/database/provision/common.go
+++ b/oracle/pkg/database/provision/common.go
@@ -427,7 +427,10 @@ func fetchMetaDataFromEnvironmentVars() (oracleHome, cdbName, version string, er
 		//the existence of the ORACLE_SID env variable isn't enough to conclude that a CDB of that name exists
 		//The existence of an oradata directory containing ORACLE_SID confirms the existence of a CDB of that name
 		if _, err = os.Stat(os.Getenv("ORACLE_BASE") + "/oradata/" + os.Getenv("ORACLE_SID")); os.IsNotExist(err) {
-			cdbName = ""
+			//After a database is provisioned, the oradata directory will be located on the DataMount
+			if _, err = os.Stat(fmt.Sprintf(consts.DataDir, consts.DataMount, os.Getenv("ORACLE_SID"))); os.IsNotExist(err) {
+				cdbName = ""
+			}
 		}
 	}
 	return os.Getenv("ORACLE_HOME"), cdbName, getOracleVersionUsingOracleHome(os.Getenv("ORACLE_HOME")), nil


### PR DESCRIPTION
After a database is provisioned, the oradata directory will be located on the DataMount. Checking $ORACLE_BASE for the oradata directory will not be enough when the oracledb container restarts.

Change-Id: I111f7a1a168f1de367432f0e3fc0e148bc42e391