### PR TITLE
Remove dependence on .metadata file

### DIFF
--- a/oracle/cmd/init_oracle/stop_oracle.sh
+++ b/oracle/cmd/init_oracle/stop_oracle.sh
@@ -22,7 +22,6 @@ if [[ "${OPT}" != "immediate" && "${OPT}" != "abort" && "${OPT}" != "force" ]]; 
   exit 1
 fi
 
-ORACLE_SID=`grep ORACLE_SID= ~/.metadata | cut -d "=" -f2`
 source /home/oracle/${ORACLE_SID}.env
 if [[ "${OPT}" == "force" ]]; then
   echo "Killing all ${ORACLE_SID} processes..."


### PR DESCRIPTION
Oracle DB images built using El Carro scripts no longer come with a .metadata file. This change was verified by provisioning an instance, deleting it and verifying that the stop_oracle.sh scripts uses the proper ORACLE_SID.

Change-Id: Ie14fb3cf8007f7189fb64efb0847c8f10ac57359