### PR TITLE
Modify express installation script to also support Oracle 19c

### DIFF
--- a/oracle/build/dbimage/install-oracle.sh
+++ b/oracle/build/dbimage/install-oracle.sh
@@ -37,9 +37,9 @@ readonly ORACLE_19="19.3"
 setup_patching() {
   if [[ "${PATCH_VERSION}" == "-1" ]]; then
     if [[ "${DB_VERSION}" == "${ORACLE_12}" ]]; then
-      PATCH_VERSION="31312468"
+      PATCH_VERSION="31741641"
     elif [[ "${DB_VERSION}" == "${ORACLE_19}" ]]; then
-      PATCH_VERSION="31281355"
+      PATCH_VERSION="32545013"
     fi
   fi
   local patch_suffix

--- a/oracle/config/samples/v1alpha1_instance_19c_EE.yaml
+++ b/oracle/config/samples/v1alpha1_instance_19c_EE.yaml
@@ -1,0 +1,41 @@
+apiVersion: oracle.db.anthosapis.com/v1alpha1
+kind: Instance
+metadata:
+  name: mydb
+spec:
+  type: Oracle
+  version: "19.3"
+  edition: Enterprise
+  dbDomain: "gke"
+  disks:
+  - name: DataDisk
+    size: 45Gi
+    storageClass: "csi-gce-pd"
+  - name: LogDisk
+    size: 55Gi
+    storageClass: "csi-gce-pd"
+  services:
+    Backup: true
+    Monitoring: true
+    Logging: true
+  sourceCidrRanges: [ 0.0.0.0/0 ]
+  images:
+    # Replace below with the actual URIs hosting the service agent images.
+    service: "gcr.io/${PROJECT_ID}/oracle-database-images/oracle-12.2-ee-seeded-${DB}"
+  cdbName: ${DB}
+  databaseResources:
+    requests:
+      memory: 4.0Gi
+
+# Uncomment this section to trigger a restore.
+#  restore:
+#    backupType: "Snapshot" #(or "Physical")
+#    backupId: "mydb-20200705-snap-996678001"
+#    force: True
+#    # once applied, new requests with same or older time will be ignored,
+#    # current time can be generated using the command: date -u '+%Y-%m-%dT%H:%M:%SZ'
+#    requestTime: "2000-01-19T01:23:45Z"
+#    # Physical backup specific attributes:
+#    dop: 2
+#    # The unit for time limit is minutes (but specify just an integer).
+#    timeLimitMinutes: 180

--- a/oracle/config/samples/v1alpha1_instance_19c_EE_express.yaml
+++ b/oracle/config/samples/v1alpha1_instance_19c_EE_express.yaml
@@ -1,0 +1,36 @@
+apiVersion: oracle.db.anthosapis.com/v1alpha1
+kind: Instance
+metadata:
+  name: mydb
+spec:
+  type: Oracle
+  version: "19.3"
+  edition: Enterprise
+  dbDomain: "gke"
+  disks:
+  - name: DataDisk
+  - name: LogDisk
+  services:
+    Backup: true
+    Monitoring: true
+    Logging: true
+    HA/DR: false
+  images:
+    # Replace below with the actual URIs hosting the service agent images.
+    service: "gcr.io/${PROJECT_ID}/oracle-database-images/oracle-19.3-ee-seeded-${DB}"
+  sourceCidrRanges: [0.0.0.0/0]
+  # Oracle SID character limit is 8, anything > gets truncated by Oracle
+  cdbName: ${DB}
+
+# Uncomment this section to trigger a restore.
+#  restore:
+#    backupType: "Snapshot" (or "Physical")
+#    backupId: "mydb-20200705-snap-996678001"
+#    force: True
+#    # once applied, new requests with same or older time will be ignored,
+#    # current time can be generated using the command: date -u '+%Y-%m-%dT%H:%M:%SZ'
+#    requestTime: "2000-01-19T01:23:45Z"
+#    # Physical backup specific attributes:
+#    dop: 2
+#    # The unit for time limit is minutes (but specify just an integer).
+#    timeLimitMinutes: 180


### PR DESCRIPTION
Change default patch version for Oracle 19c to 32545013 (latest PSU covered by our integration tests) to match instructions in quickstart guide

Change default patch version for Oracle 12c to 31741641 (latest PSU covered by our integration tests) to match instructions in quickstart guide

The new express installation script was tested locally on my machine and found to be working.

Change-Id: I7e642cb8015cf25ecc881d3999b8b9e4593ff1c9