### PR TITLE
Changed config util methods to get the default disk information from …

### DIFF
--- a/oracle/controllers/backupcontroller/backup_controller.go
+++ b/oracle/controllers/backupcontroller/backup_controller.go
@@ -88,7 +88,7 @@ func (b *snapshotBackup) create(ctx context.Context) error {
 		b.log.Info("no customer specific config found, assuming all defaults")
 	}
 
-	vsc, err := utils.FindVolumeSnapshotClassName(b.backup.Spec.VolumeSnapshotClass, configSpec, utils.PlatformGCP)
+	vsc, err := utils.FindVolumeSnapshotClassName(b.backup.Spec.VolumeSnapshotClass, configSpec, utils.PlatformGCP, utils.EngineOracle)
 	if err != nil || vsc == "" {
 		return fmt.Errorf("failed to identify a volumeSnapshotClassName for instance: %q", b.backup.Spec.Instance)
 	}

--- a/oracle/controllers/common.go
+++ b/oracle/controllers/common.go
@@ -22,12 +22,12 @@ import (
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/api/v1alpha1"
-	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/pkg/utils"
 	v1alpha1 "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/api/v1alpha1"
 	capb "github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/agents/config_agent/protos"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/agents/consts"
@@ -62,7 +62,20 @@ var (
 	CmName = "%s-cm"
 	// DatabasePodAppLabel is the 'app' label assigned to db pod.
 	DatabasePodAppLabel = "db-op"
-
+	defaultDiskSpecs    = map[string]commonv1alpha1.DiskSpec{
+		"DataDisk": {
+			Name: "DataDisk",
+			Size: resource.MustParse("100Gi"),
+		},
+		"LogDisk": {
+			Name: "LogDisk",
+			Size: resource.MustParse("150Gi"),
+		},
+		"BackupDisk": {
+			Name: "BackupDisk",
+			Size: resource.MustParse("100Gi"),
+		},
+	}
 	defaultDiskMountLocations = map[string]string{
 		"DataDisk":   "u02",
 		"LogDisk":    "u03",
@@ -117,7 +130,7 @@ type ConfigAgentClientFactory interface {
 
 // GetPVCNameAndMount returns PVC names and their corresponding mount.
 func GetPVCNameAndMount(instName, diskName string) (string, string) {
-	spec := utils.DefaultDiskSpecs[diskName]
+	spec := defaultDiskSpecs[diskName]
 	mountLocation := defaultDiskMountLocations[spec.Name]
 	pvcName := fmt.Sprintf(PvcMountName, instName, mountLocation)
 	return pvcName, mountLocation

--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -406,12 +406,12 @@ func NewPVCs(sp StsParams) ([]corev1.PersistentVolumeClaim, error) {
 		if sp.Config != nil {
 			configSpec = &sp.Config.Spec.ConfigSpec
 		}
-		rl := corev1.ResourceList{corev1.ResourceStorage: utils.FindDiskSize(&diskSpec, configSpec)}
+		rl := corev1.ResourceList{corev1.ResourceStorage: utils.FindDiskSize(&diskSpec, configSpec, defaultDiskSpecs, defaultDiskSize)}
 		pvcName, mount := GetPVCNameAndMount(sp.Inst.Name, diskSpec.Name)
 		var pvc corev1.PersistentVolumeClaim
 
 		// Determine storage class (from disk spec or config)
-		storageClass, err := utils.FindStorageClassName(&diskSpec, configSpec, utils.PlatformGCP)
+		storageClass, err := utils.FindStorageClassName(&diskSpec, configSpec, utils.PlatformGCP, utils.EngineOracle)
 		if err != nil || storageClass == "" {
 			return nil, fmt.Errorf("failed to identify a storageClassName for disk %q", diskSpec.Name)
 		}


### PR DESCRIPTION
…database services

Introduction:
This CL is for improving the util methods to be able to handle differences of oracle and postgres
There are differences in the config logic between Oracle and Postgres:
1. The default disk size is 100G for oracle and 1G for postgres.
2. For oracle, the default platform in the code is GCP. It returns an error if volumeSnapshotName/storageName is empty string https://source.corp.google.com/graybox-operator/oracle/controllers/backupcontroller/backup_controller.go;l=92;
   for postgres, there is no default platform and it allows empty volumeSnapshotName and storageName.

Change-Id: I034360fd97b83873de90abe3a1532417d302bcba