### PR TITLE
Fix volume snapshot filtering issue in the backup controller

### DIFF
--- a/common/pkg/utils/utils.go
+++ b/common/pkg/utils/utils.go
@@ -198,7 +198,7 @@ func newSnapshot(owner v1.Object, scheme *runtime.Scheme, pvcName, snapName, vol
 
 	snapshot := &snapv1.VolumeSnapshot{
 		TypeMeta:   metav1.TypeMeta{APIVersion: snapv1.SchemeGroupVersion.String(), Kind: "VolumeSnapshot"},
-		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: owner.GetNamespace(), Labels: map[string]string{"snap": snapName}},
+		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: owner.GetNamespace(), Labels: map[string]string{"name": snapName}},
 		Spec: snapv1.VolumeSnapshotSpec{
 			Source:                  snapv1.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
 			VolumeSnapshotClassName: func() *string { s := string(volumeSnapshotClassName); return &s }(),

--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -673,7 +673,7 @@ func NewPodTemplate(sp StsParams, cdbName, DBDomain string) corev1.PodTemplateSp
 func NewSnapshotInst(inst *v1alpha1.Instance, scheme *runtime.Scheme, pvcName, snapName, volumeSnapshotClassName string) (*snapv1.VolumeSnapshot, error) {
 	snap := &snapv1.VolumeSnapshot{
 		TypeMeta:   metav1.TypeMeta{APIVersion: snapv1.SchemeGroupVersion.String(), Kind: "VolumeSnapshot"},
-		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: inst.Namespace, Labels: map[string]string{"snap": snapName}},
+		ObjectMeta: metav1.ObjectMeta{Name: snapName, Namespace: inst.Namespace, Labels: map[string]string{"name": snapName}},
 		Spec: snapv1.VolumeSnapshotSpec{
 			Source:                  snapv1.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
 			VolumeSnapshotClassName: func() *string { s := string(volumeSnapshotClassName); return &s }(),


### PR DESCRIPTION
The selector API was being incorrectly used. https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector_test.go#L757 shows proper usage. Instead of using the selector returned by selector.Add(), we were using the selector passed to selector.Add() which never got modified after getting initialized as nil. As a result, the selector passed to the kubernetes API server was always nil and all volume snapshots for all backups got returned unfiltered. As a safeguard against incorrect filtering, I'm also adding a check to ensure that the K8s API server doesn't return more than 2 volume snapshots.

Change the label we attach to our volume snapshots to be "name" since that's what the backup controller filters on, not "snap".

Removing the namespace label selector because we do not even add a namespace label to our volume snapshots and because we use the InNamespace ListOption when calling the k8s API server.

Change-Id: Ife6e8cc9229e81bf7bed907bdb236bb3bad12c30