### PR TITLE
Preserve analysis cache during make test

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -102,13 +102,14 @@ test:
 	# Load oracle image paths from env variables to .bazelrc
 	envsubst < controllers/inttest/.bazelrc.tmpl > controllers/inttest/.bazelrc
 	# Integration tests, build unlimited, but limit test jobs.
-	bazel build --test_tag_filters="integration" ... || touch failed
+	bazel build --@io_bazel_rules_go//go/config:race --test_tag_filters="integration" ... || touch failed
 	bazel \
 		--bazelrc=controllers/inttest/.bazelrc \
 		test \
 		--jobs=10 \
 		--local_cpu_resources=10 \
 		--test_tag_filters="integration" \
+		--@io_bazel_rules_go//go/config:race \
 		... \
 		--test_output=errors \
 		--spawn_strategy=local \


### PR DESCRIPTION
Race flags are part of the analysis cache so switching it causes the
whole cache to be invalidated. We can retain the analysis by using race
detector for the integration tests too.

Change-Id: Ie86261ff0fd7e870a2e30e84e4bd22ef63067ae3