### PR TITLE
Change 22621 Add a NamespaceMapper.

### DIFF
--- a/common/pkg/ns/BUILD.bazel
+++ b/common/pkg/ns/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "ns",
+    srcs = ["ns.go"],
+    importpath = "github.com/GoogleCloudPlatform/elcarro-oracle-operator/common/pkg/ns",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "ns_test",
+    srcs = ["ns_test.go"],
+    embed = [":ns"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/common/pkg/ns/ns.go
+++ b/common/pkg/ns/ns.go
@@ -1,0 +1,118 @@
+// Package ns provides a way to map entities from one namespace into another.
+// The key idea here is that we can reduce the operator's privilege by only
+// granting it privileges in a separate namespace which is not the same as where
+// the operator's custom resources are created.
+package ns
+
+import (
+	"hash/fnv"
+)
+
+// NamespaceMapper maps an entity namespace/name to another namespace/name.
+type NamespaceMapper interface {
+	// DestName returns the destination name of a given namespace/name.
+	DestName(srcNS, srcName string) string
+
+	// DestNamespace returns the destination namespace for a given namespace.
+	DestNamespace(srcNS string) string
+}
+
+// NewSameMapper returns a NamespaceMapper that maps to the same namespace/name.
+func NewSameMapper() NamespaceMapper {
+	return &same{}
+}
+
+// NewRedirectMapper returns a NamespaceMapper that redirects all entities to
+// one select target namespace.
+// To avoid collision of the same name from different namespaces, the mapper
+// prefixes the source-namespace and appends a hash.
+// Long names may get truncated.
+// Examples:
+// destNs: "target"
+// { ns: "a", "name: "b" } -> { ns: "target", name: "a-b-hash" }
+// { ns: "", name: "c" } -> { ns: "target", name: "c-hash" }
+func NewRedirectMapper(destNS string) NamespaceMapper {
+	return &redirectToAnother{TargetNS: destNS}
+}
+
+// NewNSPrefixMapper returns a NamespaceMapper that redirects all entities to
+// another namespace with the specified prefix. The entity name doesn't change.
+// The destination namespace may have a prefix-hash appended at the end for
+// long names (with truncation).
+// Examples, for namespace prefix "pre"
+// { ns: "a", "name: "b" } -> { ns: "pre-a", name: "b" }
+// { ns: "", name: "c" } -> { ns: "pre", name: "c" }
+// { ns: "long-name", name: "c" } -> { ns: "pre-long-clipped-hash", name: "c" }
+func NewNSPrefixMapper(nsPrefix string) NamespaceMapper {
+	return &prefixer{prefix: nsPrefix}
+}
+
+type same struct{}
+
+func (*same) DestName(srcNS, srcName string) string {
+	return srcName
+}
+
+func (*same) DestNamespace(srcNS string) string {
+	return srcNS
+}
+
+type prefixer struct {
+	prefix string
+}
+
+func (r *prefixer) DestName(srcNS, srcName string) string {
+	return srcName
+}
+
+func (r *prefixer) DestNamespace(srcNS string) string {
+	return munge(r.prefix, srcNS, 63, false)
+}
+
+type redirectToAnother struct {
+	TargetNS string
+}
+
+func (r *redirectToAnother) DestName(srcNS, srcName string) string {
+	return munge(srcNS, srcName, 63, true)
+}
+
+func (r *redirectToAnother) DestNamespace(srcNS string) string {
+	return r.TargetNS
+}
+
+func munge(s1, s2 string, limit int, alwaysAddHash bool) string {
+	j := s1 + "-" + s2
+	if len(s1) == 0 {
+		j = s2
+	}
+	if len(s2) == 0 {
+		j = s1
+	}
+	hashRequired := alwaysAddHash
+	if len(j) > limit-suffixLen {
+		j = j[:limit-suffixLen]
+		hashRequired = true
+	}
+	if hashRequired {
+		j = j + hashSuffix(s1+"/"+s2)
+	}
+	return j
+}
+
+var charset = []rune("01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+const suffixLen = 12
+
+func hashSuffix(s string) string {
+	e := fnv.New64()
+	e.Write([]byte(s))
+	i := e.Sum64()
+	c := []rune{'-'}
+	l := uint64(len(charset))
+	for i > 0 {
+		c = append(c, charset[i%l])
+		i /= l
+	}
+	return string(c)
+}

--- a/common/pkg/ns/ns_test.go
+++ b/common/pkg/ns/ns_test.go
@@ -1,0 +1,117 @@
+package ns
+
+import "testing"
+
+func TestRedirectToAnotherDestNamespace(t *testing.T) {
+	rdo := NewRedirectMapper("target-ns")
+	got := rdo.DestNamespace("abc")
+	if got != "target-ns" {
+		t.Errorf("RedirectToAnother.DestNamespace(); got %v, wantName %v", got, "target-ns")
+	}
+}
+
+func TestRedirectToAnotherNS(t *testing.T) {
+	rdm := NewRedirectMapper("target-ns")
+	pm := NewNSPrefixMapper("ods")
+	tests := []struct {
+		name     string
+		mapper   NamespaceMapper
+		srcNS    string
+		srcName  string
+		wantNS   string
+		wantName string
+	}{
+		{
+			name:     "NewRedirectMapper: small ns and name",
+			mapper:   rdm,
+			srcNS:    "a",
+			srcName:  "b",
+			wantNS:   "target-ns",
+			wantName: "a-b-YnZ12Te9xRe",
+		},
+		{
+			name:     "NewRedirectMapper: empty ns and small name",
+			mapper:   rdm,
+			srcNS:    "",
+			srcName:  "a-b",
+			wantNS:   "target-ns",
+			wantName: "a-b-r2ZyZy9wnnf",
+		},
+		{
+			name:     "NewRedirectMapper: limit ns and name",
+			mapper:   rdm,
+			srcNS:    "abcdefghijklmnopqrstuvwxyz",
+			srcName:  "abcedfghijklmnopqrstuvwx",
+			wantNS:   "target-ns",
+			wantName: "abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrstuvwx-d1B2eQE0Vn5",
+		},
+		{
+			name:     "NewRedirectMapper: hashed name",
+			mapper:   rdm,
+			srcNS:    "abcdefghijklmnopqrstuvwxyz",
+			srcName:  "abcedfghijklmnopqrstuvwxy",
+			wantNS:   "target-ns",
+			wantName: "abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrstuvwx-wEHR2lf6B2h",
+		},
+		{
+			name:     "NewRedirectMapper: another hashed name; different suffix",
+			mapper:   rdm,
+			srcNS:    "abcdefghijklmnopqrstuvwxyz",
+			srcName:  "abcdefghijklmnopqrstuvwxyz",
+			wantNS:   "target-ns",
+			wantName: "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwx-QPxNa2k0Ynb",
+		},
+		{
+			name:     "NewNSPrefixMapper: small ns and name",
+			mapper:   pm,
+			srcNS:    "a",
+			srcName:  "b",
+			wantNS:   "ods-a",
+			wantName: "b",
+		},
+		{
+			name:     "NewNSPrefixMapper: empty ns and small name",
+			mapper:   pm,
+			srcNS:    "",
+			srcName:  "b",
+			wantNS:   "ods",
+			wantName: "b",
+		},
+		{
+			name:     "NewNSPrefixMapper: limit ns and name",
+			mapper:   pm,
+			srcNS:    "abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrst",
+			srcName:  "abcedfghijklmnopqrstuvwx",
+			wantNS:   "ods-abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrst",
+			wantName: "abcedfghijklmnopqrstuvwx",
+		},
+		{
+			name:     "NewNSPrefixMapper: hashed name",
+			mapper:   pm,
+			srcNS:    "abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrstuvwxyz",
+			srcName:  "abcdefghijklmnopqrstuvwxyz",
+			wantNS:   "ods-abcdefghijklmnopqrstuvwxyz-abcedfghijklmnopqrst-ssf0qZp8vw7",
+			wantName: "abcdefghijklmnopqrstuvwxyz",
+		},
+		{
+			name:     "NewNSPrefixMapper: another hashed name; different suffix",
+			mapper:   pm,
+			srcNS:    "012345678901234567890123456789012345678901234567890",
+			srcName:  "abcdefghijklmnopqrstuvwxyz",
+			wantNS:   "ods-01234567890123456789012345678901234567890123456-tVvZbfl0sDd",
+			wantName: "abcdefghijklmnopqrstuvwxyz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mapper.DestName(tt.srcNS, tt.srcName)
+			if got != tt.wantName {
+				t.Errorf("mapper.DestName(); got %v, wantName %v; len(got) %v, len(wat) %v", got, tt.wantName, len(got), len(tt.wantName))
+			}
+			got = tt.mapper.DestNamespace(tt.srcNS)
+			if got != tt.wantNS {
+				t.Errorf("mapper.DestNamespace(); got %v, wantName %v; len(got) %v, len(wat) %v", got, tt.wantNS, len(got), len(tt.wantNS))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a NamespaceMapper.

The namespace mapper maps a {namespace, name} pair to
another {namespace, name} pair.

Mapping to another namespace allows the operator to operate with
reduced privileges in the source namespace and more privileges in
the destination namespace.

Change-Id: I64843abe2b8e0e1a045251294df7503084eabd36