### PR TITLE
Fail tests when status is Failed

### DIFF
--- a/oracle/controllers/backupschedulecontroller/functest/BUILD.bazel
+++ b/oracle/controllers/backupschedulecontroller/functest/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "functest_test",
     size = "medium",
     srcs = ["backupschedule_controller_functional_test.go"],
+    tags = ["functional"],
     deps = [
         "//common/api/v1alpha1",
         "//oracle/api/v1alpha1",

--- a/oracle/pkg/k8s/condition.go
+++ b/oracle/pkg/k8s/condition.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"strings"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,6 +91,15 @@ func FindCondition(conditions []v1.Condition, name string) *v1.Condition {
 		}
 	}
 	return nil
+}
+
+func FindConditionOrFailed(conditions []v1.Condition, name string) (bool, *v1.Condition) {
+	for i, c := range conditions {
+		if c.Type == name {
+			return strings.Contains(c.Reason, "Failed"), &conditions[i]
+		}
+	}
+	return false, nil
 }
 
 func ConditionStatusEquals(cond *v1.Condition, status v1.ConditionStatus) bool {


### PR DESCRIPTION
*Failed statuses are unreconcilable and indicate the object should be
deleted and resubmitted. As such the tests should not attempt to wait
for that status to change from Failed (because it wont).

This makes tests fail immediately reducing the time to wait for test
logs.

Also add's functional tag to the backupschedulecontroller's functional
test.

Change-Id: If8bd91628b5cb422e2f932edb817ff8b43577de5