### PR TITLE
[PE] Set bazel test timeout  3600s->7200s for 'eternal' tests. 

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -107,6 +107,7 @@ test:
 		--local_cpu_resources=10 \
 		--test_tag_filters="integration" \
 		--@io_bazel_rules_go//go/config:race \
+		--test_timeout=60,300,900,7200 \
 		... \
 		--test_output=errors \
 		--spawn_strategy=local \


### PR DESCRIPTION
This is necessary for unseeded instance tests.

Change-Id: Id8bfaf11f22e631bbfc1aa9fdcef95ae5940ca8b