### PR TITLE
Add dev-container make rule

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -199,6 +199,37 @@ deploy: generate-config
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${PROW_IMAGE_REPO}/${PROW_PROJECT}/oracle.db.anthosapis.com/operator:${PROW_IMAGE_TAG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+# In case your native environment's abi is incompatible with OEL8 (GLIBC errors)
+# this will take you into a build environment similar to our CI
+# where you can build with abi compatibility. With podman we could use --env-host
+dev-container:
+	env | grep -v '^HOME\|^XDG\|^TMP\|^PATH\|^USER' > /tmp/env_host
+	docker run --rm -it --entrypoint="" \
+		--env-file=/tmp/env_host \
+		--env PATH="/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH}" \
+		--mount=type=bind,src=$(shell readlink -f ../),dst=/workspace/code \
+		--mount=type=bind,src=$(shell readlink -f ~/.cache/bazel),dst=/root/.cache/bazel \
+		--mount=type=bind,src=$(shell readlink -f ~/.config/),dst=/root/.config/ \
+		gcr.io/k8s-testimages/kubekins-e2e:latest-master \
+		/bin/sh -c "/workspace/code/oracle/scripts/install_prow_deps.sh && gcloud container clusters get-credentials --zone=${PROW_CLUSTER_ZONE} ${PROW_CLUSTER} && cd /workspace/code/oracle && /bin/bash"
+
+# Instead of entering the dev-container just build and push containers.  We
+# only call gcloud auth configure-docker instead of the full install steps
+# since we wont be running formatting and verification here and it makes the
+# container startup much faster.  This must also cleanup the bazel-* symlinks
+# which will get overwritten in the host.
+buildah-push-all-containerized:
+	env | grep -v '^HOME\|^XDG\|^TMP\|^PATH\|^USER' > /tmp/env_host
+	docker run --rm -it --entrypoint="" \
+		--env-file=/tmp/env_host \
+		--env PATH="/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:${PATH}" \
+		--mount=type=bind,src=$(shell readlink -f ../),dst=/workspace/code \
+		--mount=type=bind,src=$(shell readlink -f ~/.cache/bazel),dst=/root/.cache/bazel \
+		--mount=type=bind,src=$(shell readlink -f ~/.config/),dst=/root/.config/ \
+		gcr.io/k8s-testimages/kubekins-e2e:latest-master \
+		/bin/sh -c "gcloud auth configure-docker --quiet && cd /workspace/code/oracle && make buildah-push-all && rm /workspace/code/bazel-*"
+
+
 # Install all the required dependencies for prow.
 prepare-prow:
 	scripts/install_prow_deps.sh || (echo "*** Retrying install prow deps*** "; scripts/install_prow_deps.sh)

--- a/oracle/scripts/install_prow_deps.sh
+++ b/oracle/scripts/install_prow_deps.sh
@@ -35,36 +35,14 @@ EOF
 INSTALL_TMP_DIR=$(mktemp -d)
 cd $INSTALL_TMP_DIR
 
-# add debian 10 buildah repo from https://github.com/containers/buildah/blob/master/install.md
-echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_10/Release.key -O Release.key
-apt-key add - < Release.key
-
 # everything we can get from debian packages.
 apt-get update -qq
 apt-get install -y \
-  clang-format buildah fuse-overlayfs gettext-base jq
-
-# Use fuse-overlayfs to run buildah within k8s container.
-sed -i -e 's|#mount_program = "/usr/bin/fuse-overlayfs"|mount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf
+  clang-format gettext-base jq
 
 # Link the kubekins install to the typical debian location to match Dev
 # machines.
 ln -s /google-cloud-sdk /usr/lib/google-cloud-sdk
-
-# install binaries for testing
-KUBEBUILDER_VER="2.3.1"
-HOST_OS=$(go env GOOS)
-HOST_ARCH=$(go env GOARCH)
-
-# Get kubebuilder (includes kubectl, kube-apiserver, etcd)
-curl -sSL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VER}/kubebuilder_${KUBEBUILDER_VER}_${HOST_OS}_${HOST_ARCH}.tar.gz \
-  -o kubebuilder.tar.gz
-mkdir kubebuilder
-tar xvf kubebuilder.tar.gz --strip-components=1 -C kubebuilder
-# Typical install location /usr/local/kubebuilder/bin/
-rm -fr /usr/local/kubebuilder
-mv kubebuilder /usr/local/
 
 # If we need a specific kubectl from gcr.io/k8s-testimages/kubekins-e2e
 # rm /usr/local/bin/kubectl


### PR DESCRIPTION
This adds a makefile rule to enter a container where you can run bazel
and build artifacts with ABI compatibility to OEL8. This is most helpful
when your local machine has a newer version of GLIBC than OEL8 which can
result in ABI incompatibilities and missing symbol errors when launching
containers.

Also clean up the install_prow_deps.sh to remove unused packages.

Change-Id: I2051d2ac0c5fa87993989b4ac7442b73a638432b