### PR TITLE
Oracle build patch out jndi class files

### DIFF
--- a/oracle/build/dbimage/install-oracle.sh
+++ b/oracle/build/dbimage/install-oracle.sh
@@ -326,6 +326,14 @@ run_sql() {
   echo "${1}" | sudo -E -u oracle "${OHOME}/bin/sqlplus" -S / as sysdba
 }
 
+patch_log4j(){
+  # Delete Jndi classes from log4j jars as part of CVE-2021-44228
+  # While waiting for oracle patches.
+  for f in $(find "${OHOME}" -type f -name "log4j-core*.jar"); do
+    sudo -u oracle zip -q -d "$f" org/apache/logging/log4j/core/lookup/JndiLookup.class || true
+  done
+}
+
 main() {
   setup_patching
   setup_installers
@@ -347,6 +355,7 @@ main() {
   fi
   chown "${USER}:${GROUP}" /etc/oratab
   cleanup_post_success
+  patch_log4j
   echo "Oracle installation success"
 }
 main

--- a/oracle/build/dbimage/oracle-preinstall.sh
+++ b/oracle/build/dbimage/oracle-preinstall.sh
@@ -23,7 +23,7 @@ readonly USER='oracle'
 readonly GROUP='dba'
 
 install_packages() {
-  yum install -y shadow-utils openssl sudo
+  yum install -y shadow-utils openssl sudo zip
   yum install -y nmap-ncat.x86_64
   yum install -y strace.x86_64
   yum install -y net-tools.x86_64


### PR DESCRIPTION
This is a temporary mitigation for the log4j CVE, we recommend removing
all 12c instances until Oracle releases patches and confirms
non-exploitability of the database.

Change-Id: I36bb251c042fccc9a9f67a3298fd71f29fcb5841