### PR TITLE
Update images to use numeric IDs

### DIFF
--- a/oracle/BUILD.bazel
+++ b/oracle/BUILD.bazel
@@ -62,14 +62,14 @@ container_image(
         "@distroless//image:002.tar.gz",
         "@busybox//image:000.tar.gz",  # duplicated files will be retained from the lowest layer.
     ],
-    user = "nonroot:nonroot",
+    user = "65532:65532",  # nonroot:nonroot. Container admission tools require ids to guarentee nonroot.
     visibility = ["//visibility:public"],
 )
 
 container_image(
     name = "base_image",
     base = "@distroless//image",
-    user = "nonroot:nonroot",
+    user = "65532:65532",  # nonroot:nonroot. Container admission tools require ids to guarentee nonroot.
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Numeric IDs are required by some container admission systems to enforce
non-root containers are actually non-root.

Change-Id: I67298522905d69a32c6771c3275acb2071a5d3df