### PR TITLE
Adjust logging to capture setup errors

### DIFF
--- a/oracle/controllers/inttest/usertest/BUILD.bazel
+++ b/oracle/controllers/inttest/usertest/BUILD.bazel
@@ -18,6 +18,8 @@ ginkgo_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_client_go//plugin/pkg/client/auth/gcp",
         "@io_k8s_client_go//util/retry",
+        "@io_k8s_klog_v2//:klog",
+        "@io_k8s_klog_v2//klogr",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/log",
     ],

--- a/oracle/controllers/inttest/usertest/user_test.go
+++ b/oracle/controllers/inttest/usertest/user_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// Enable GCP auth for k8s client
@@ -67,6 +69,10 @@ var (
 
 // Initial setup before test suite.
 var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+
+	log = logf.FromContext(nil)
 	// Note that these GSM + WI setup steps are re-runnable.
 	// If the env fulfills, no error should occur.
 


### PR DESCRIPTION
We were previously logging to stdout which might not be captured in
normal test output.

Change-Id: I32410d50071aed5101f6c9a3f1943b6f8fdb5213