### PR TITLE
Remove "-c" from oracle-preinstall.sh invocation

### DIFF
--- a/oracle/build/dbimage/Dockerfile
+++ b/oracle/build/dbimage/Dockerfile
@@ -27,7 +27,7 @@ ARG CREATE_CDB
 ARG CDB_NAME
 ENV STAGE_DIR=/tmp/stage/
 COPY oracle-preinstall.sh $STAGE_DIR
-RUN /bin/bash -c $STAGE_DIR/oracle-preinstall.sh
+RUN /bin/bash $STAGE_DIR/oracle-preinstall.sh
 
 FROM base as installer
 


### PR DESCRIPTION
`bash -c` executes the arguments as a child process [1], which requires `oracle-preinstall.sh` to be executable.  Since the dockerfile doesn't explicitly chmod files, this isn't always a safe assumption to make.  When I attempt to follow the [quickstart guide steps](https://github.com/GoogleCloudPlatform/elcarro-oracle-operator/blob/main/docs/content/quickstart-19c-ee.md#option-1-using-google-cloud-build-to-create-a-containerized-oracle-database-image-recommended) using a release an El Carro release originally from a GCS bucket, I get the following error:

```
Step #1: Step 9/37 : RUN /bin/bash -c $STAGE_DIR/oracle-preinstall.sh
Step #1:  ---> Running in 3dee1ff869bf
Step #1: /bin/bash: /tmp/stage//oracle-preinstall.sh: Permission denied
Step #1: The command '/bin/sh -c /bin/bash -c $STAGE_DIR/oracle-preinstall.sh' returned a non-zero code: 126
```

When I remove the `-c` from the bash call, the error goes away and the install continues.

[1] https://unix.stackexchange.com/questions/179288/difference-between-bash-executable-and-bash-c-executable