### PR TITLE
Fix bug in testhelpers k8sUpdateWithRetryHelper

### DIFF
--- a/oracle/controllers/testhelpers/BUILD.bazel
+++ b/oracle/controllers/testhelpers/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",

--- a/oracle/controllers/testhelpers/envtest.go
+++ b/oracle/controllers/testhelpers/envtest.go
@@ -39,6 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1099,7 +1100,11 @@ func k8sUpdateWithRetryHelper(k8sClient client.Client,
 	Eventually(
 		func() string {
 			// Get a fresh version of the object
-			K8sGetWithRetry(k8sClient, ctx, objKey, emptyObj)
+			err := k8sClient.Get(ctx, objKey, emptyObj)
+			if apierrors.IsNotFound(err) {
+				return originalRV + "-deleted"
+			}
+			Expect(err).ToNot(HaveOccurred())
 			return emptyObj.GetResourceVersion()
 		}, RetryTimeout, RetryInterval).Should(Not(Equal(originalRV)))
 }


### PR DESCRIPTION
In `k8sUpdateWithRetryHelper` after updating the object we make an extra `Get` to make sure the object has changed. This causes problems in scenarios where the object gets deleted after the update (e.g., by another controller).

For example in my test I'm using this helper to update an object and remove it's finalizer. After removing the finalizer the object is removed and so the test fails on line `envtest.go:1102` when it tries to fetch the object again to compare resourceVersions.

I made a small change to handle this case.