### PR TITLE
Fix tag on UI image

### DIFF
--- a/oracle/ui.yaml
+++ b/oracle/ui.yaml
@@ -158,7 +158,7 @@ spec:
     spec:
       containers:
       - name: ui
-        image: gcr.io/elcarro/oracle.db.anthosapis.com/ui:latest
+        image: gcr.io/elcarro/oracle.db.anthosapis.com/ui:v0.1.0-alpha
         imagePullPolicy: Always
 ---
 apiVersion: v1


### PR DESCRIPTION
The upstream UI image `gcr.io/elcarro/oracle.db.anthosapis.com/ui` does not have a `latest` tag:

```
$ curl -s https://gcr.io/v2/elcarro/oracle.db.anthosapis.com/ui/tags/list | jq '.tags'
[
  "v0.0.0-alpha",
  "v0.1.0-alpha"
]
```

It results in an error when installing the UI as per https://github.com/GoogleCloudPlatform/elcarro-oracle-operator/blob/main/docs/content/monitoring/ui.md

```
Failed to pull image "gcr.io/elcarro/oracle.db.anthosapis.com/ui:latest": rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/elcarro/oracle.db.anthosapis.com/ui:latest": failed to resolve reference "gcr.io/elcarro/oracle.db.anthosapis.com/ui:latest": gcr.io/elcarro/oracle.db.anthosapis.com/ui:latest: not found
```

Following the convention in `operator.yaml`, here we change the tag to `v0.1.0-alpha`.  With this change , the UI installs successfully:

```
$ kubectl describe pod -n ui | tail
 Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                              node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
 Events:
   Type    Reason     Age   From               Message
   ----    ------     ----  ----               -------
   Normal  Scheduled  25s   default-scheduler  Successfully assigned ui/ui-659665f8cb-5wlrz to 4633612-svr004
   Normal  Pulling    24s   kubelet            Pulling image "gcr.io/elcarro/oracle.db.anthosapis.com/ui:v0.1.0-alpha"
   Normal  Pulled     23s   kubelet            Successfully pulled image "gcr.io/elcarro/oracle.db.anthosapis.com/ui:v0.1.0-alpha" in 1.341448841s
   Normal  Created    23s   kubelet            Created container ui
   Normal  Started    23s   kubelet            Started container ui
```