### PR TITLE
Clean up doc references to configagent

### DIFF
--- a/docs/content/kind.md
+++ b/docs/content/kind.md
@@ -159,7 +159,7 @@ curl http://localhost:5000/v2/_catalog
 
 You should see an output similar to this:
 ```sh
-{"repositories":["oracle-12.2-ee-seeded-mydb","local/oracle.db.anthosapis.com/configagent","local/oracle.db.anthosapis.com/dbinit","local/oracle.db.anthosapis.com/loggingsidecar","local/oracle.db.anthosapis.com/monitoring","local/oracle.db.anthosapis.com/operator"]}
+{"repositories":["oracle-12.2-ee-seeded-mydb","local/oracle.db.anthosapis.com/dbinit","local/oracle.db.anthosapis.com/loggingsidecar","local/oracle.db.anthosapis.com/monitoring","local/oracle.db.anthosapis.com/operator"]}
 ```
 
 ### Setup a namespace

--- a/docs/content/minikube.md
+++ b/docs/content/minikube.md
@@ -164,7 +164,7 @@ curl http://localhost:5000/v2/_catalog
 
 You should see an output similar to this:
 ```sh
-{"repositories":["oracle-12.2-ee-seeded-mydb","local/oracle.db.anthosapis.com/configagent","local/oracle.db.anthosapis.com/dbinit","local/oracle.db.anthosapis.com/loggingsidecar","local/oracle.db.anthosapis.com/monitoring","local/oracle.db.anthosapis.com/operator"]}
+{"repositories":["oracle-12.2-ee-seeded-mydb","local/oracle.db.anthosapis.com/dbinit","local/oracle.db.anthosapis.com/loggingsidecar","local/oracle.db.anthosapis.com/monitoring","local/oracle.db.anthosapis.com/operator"]}
 ```
 
 ### Setup a namespace:

--- a/docs/content/provision/config.md
+++ b/docs/content/provision/config.md
@@ -43,7 +43,6 @@ To get El Carro up and running, you need to do one the following:
       images:
         # Replace below with the actual URIs hosting the service agent images.
         service: "gcr.io/${PROJECT_ID}/oracle-database-images/oracle-12.2-ee-unseeded"
-        config: "gcr.io/${PROJECT_ID}/oracle.db.anthosapis.com/configagent:latest"
       platform: "GCP"
       disks: [
       {
@@ -111,7 +110,6 @@ To get El Carro up and running, you need to do one the following:
         Size:  150Gi
         Type:  pd-standard
       Images:
-        Config:               gcr.io/${PROJECT_ID}/oracle.db.anthosapis.com/configagent:latest
         Service:              gcr.io/${PROJECT_ID}/oracle-database-images/oracle-12.2ee-unseeded
       Platform:               GCP
       Volume Snapshot Class:  csi-gce-pd-snapshot-class

--- a/oracle/config/samples/v1alpha1_config_gcp2.yaml
+++ b/oracle/config/samples/v1alpha1_config_gcp2.yaml
@@ -6,7 +6,6 @@ spec:
   images:
     # Replace below with the actual URIs hosting the service agent images.
     service: "gcr.io/${PROJECT_ID}/oracle-database-images/oracle-12.2-ee-unseeded"
-    config: "gcr.io/${PROJECT_ID}/oracle.db.anthosapis.com/configagent:latest"
   platform: "GCP"
   disks: [
   {

--- a/oracle/config/samples/v1alpha1_config_kind.yaml
+++ b/oracle/config/samples/v1alpha1_config_kind.yaml
@@ -8,7 +8,6 @@ spec:
   volumeSnapshotClass: "csi-hostpath-snapclass"
   images:
     service: "gcr.io/oracle-database-images/oracle-12.2-ee-seeded-mydb:kind"
-    config: "gcr.io/oracle.db.anthosapis.com/configagent:kind"
     dbinit: "gcr.io/oracle.db.anthosapis.com/dbinit:kind"
     logging_sidecar: "gcr.io/oracle.db.anthosapis.com/loggingsidecar:kind"
     monitoring: "gcr.io/oracle.db.anthosapis.com/monitoring:kind"

--- a/oracle/config/samples/v1alpha1_config_minikube.yaml
+++ b/oracle/config/samples/v1alpha1_config_minikube.yaml
@@ -11,5 +11,4 @@ spec:
     dbinit: "localhost:5000/oracle.db.anthosapis.com/dbinit:latest"
     dbdaemon_client: "localhost:5000/oracle.db.anthosapis.com/dbdaemon_client:latest"
     logging_sidecar: "localhost:5000/oracle.db.anthosapis.com/loggingsidecar:latest"
-    config: "localhost:5000/oracle.db.anthosapis.com/configagent:latest"
     monitoring: "localhost:5000/oracle.db.anthosapis.com/monitoring:latest"


### PR DESCRIPTION
configagent was removed entirely in #196.  Here we clean up
documentation references to a now-nonexistant configagent container.