### PR TITLE
Use Internal Load Balancer in Namespace integration test

### DIFF
--- a/oracle/controllers/inttest/namespacetest/namespace_test.go
+++ b/oracle/controllers/inttest/namespacetest/namespace_test.go
@@ -156,6 +156,9 @@ func createInstance(instanceName, cdbName, namespace, version, edition, extra st
 				Images: map[string]string{
 					"service": testhelpers.TestImageForVersion(version, edition, extra),
 				},
+				DBLoadBalancerOptions: &commonv1alpha1.DBLoadBalancerOptions{
+					GCP: commonv1alpha1.DBLoadBalancerOptionsGCP{LoadBalancerType: "Internal"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The provisioning of External load balancer in our new GCP folder has yet to be enabled. In the meantime, we've been relying on provisioning internal load balancers. For the error that this change fixes, see https://prow-gob.gcpnode.com/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Fgob-prow%2Flogs%2Foperator-canary%2F1538839239137955840%22%7D&topURL=https%3A//prow-gob.gcpnode.com/view/gcs/gob-prow/logs/operator-canary/1538839239137955840&lensIndex=1#build-log.txt:62634

Change-Id: I958c863d115c0bc20780733fc6d7262176bbc9d4