### PR TITLE
Increase operator memory limits

### DIFF
--- a/oracle/config/manager/manager.yaml
+++ b/oracle/config/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 40Mi
+            memory: 60Mi
           requests:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -2875,8 +2875,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 40Mi
+            memory: 60Mi
           requests:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
When testing on bare metal environments, I'm seeing restarts due to out-of-memory conditions.  For example:

```
manager invoked oom-killer: gfp_mask=0x6000c0(GFP_KERNEL), order=0, oom_score_adj=999
CPU: 40 PID: 1476973 Comm: manager Kdump: loaded Tainted: G          I      --------- -  - 4.18.0-305.25.1.el8_4.x86_64 #1
...
memory: usage 40960kB, limit 40960kB, failcnt 318
Memory cgroup stats for /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1fe4ac3b_fed7_45d6_8ba9_b81361ddffc5.slice/cri-containerd-39a63070dceb191a7c2cd62666b29a747eacf7f6d10f8f5df05aea57470dcbd8.scope:
anon 38109184#012file 0#012kernel_stack 184320#012slab 0#012percpu 0#012sock 0#012shmem 0#012file_mapped 0#012file_dirty 0#012file_writeback 0#012anon_thp 0#012inactive_anon 38576128#012active_anon 0#012inactive_file 0#012active_file 0#012unevictable 0#012slab_reclaimable 0#012slab_unreclaimable 0#012pgfault 11220#012pgmajfault 0#012workingset_refault_anon 0#012workingset_refault_file 0#012workingset_activate_anon 0#012workingset_activate_file 0#012workingset_restore_anon 0#012workingset_restore_file 0#012workingset_nodereclaim 0#012pgrefill 0#012pgscan 0#012pgsteal 0#012pgactivate 0#012pgdeactivate 0#012pglazyfree 0#012pglazyfreed 0#012thp_fault_alloc 0#012thp_collapse_alloc 0
Tasks state (memory values in pages):
[  pid  ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
[1473780] 65532 1473780   981102    16623   614400        0           999 manager
oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-39a63070dceb191a7c2cd62666b29a747eacf7f6d10f8f5df05aea57470dcbd8.scope,mems_allowed=0-1,oom_memcg=/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1fe4ac3b_fed7_45d6_8ba9_b81361ddffc5.slice/cri-containerd-39a63070dceb191a7c2cd62666b29a747eacf7f6d10f8f5df05aea57470dcbd8.scope,task_memcg=/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1fe4ac3b_fed7_45d6_8ba9_b81361ddffc5.slice/cri-containerd-39a63070dceb191a7c2cd62666b29a747eacf7f6d10f8f5df05aea57470dcbd8.scope,task=manager,pid=1473780,uid=65532
```

Upping the limit from 40Mi to 60Mi, the errors have gone away for me.

Change-Id: I63684199d6ce2a5c59cf97547c4edd56f8c8e4ff