### PR TITLE
Increase database creation timeout

### DIFF
--- a/oracle/controllers/databasecontroller/database_resources.go
+++ b/oracle/controllers/databasecontroller/database_resources.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	dialTimeout = 3 * time.Minute
+	dialTimeout = 10 * time.Minute
 )
 
 // NewDatabase attempts to create a new PDB if it doesn't exist yet.


### PR DESCRIPTION
On systems with slow storage, database creation can take well over three minutes, resulting in hung database creation requests and errors in the operator logs like

```
controller.go:302] controller-runtime/manager/controller/database "msg"="Reconciler error" "error"="resource/NewDatabase: failed on CreateDatabase gRPC call: config_agent_helpers/CreatePDBDatabase: PDB PDB1 open failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded" "name"="pdb1" "namespace"="db" "reconciler group"="oracle.db.anthosapis.com" "reconciler kind"="Database" 
...
controller.go:302] controller-runtime/manager/controller/database "msg"="Reconciler error" "error"="resource/NewDatabase: failed on CreateDatabase gRPC call: failed to alter user GPDB_ADMIN: rpc error: code = Unknown desc = ORA-01109: database not open" "name"="pdb1" "namespace"="db" "reconciler group"="oracle.db.anthosapis.com" "reconciler kind"="Database" 
```

Increasing the timeout to 10 minutes, considering that many timeouts end up requiring manual cleanup.

Change-Id: I5924ea0b33cdce9bfa82851896cd2eace1462195