### PR TITLE
Adjust log level on successful provisioning

### DIFF
--- a/oracle/cmd/init_oracle/init_oracle.go
+++ b/oracle/cmd/init_oracle/init_oracle.go
@@ -213,7 +213,7 @@ func main() {
 			os.Exit(consts.DefaultExitErrorCode)
 		}
 
-		klog.InfoS(err, "CDB provisioning DONE")
+		klog.InfoS("CDB provisioning DONE")
 	}
 }
 

--- a/oracle/cmd/init_oracle/init_oracle.go
+++ b/oracle/cmd/init_oracle/init_oracle.go
@@ -213,7 +213,7 @@ func main() {
 			os.Exit(consts.DefaultExitErrorCode)
 		}
 
-		klog.ErrorS(err, "CDB provisioning DONE")
+		klog.InfoS(err, "CDB provisioning DONE")
 	}
 }
 


### PR DESCRIPTION
Currently a successful database provisioning operation is reported with an "Error" log level.  For example:

```
I0804 21:21:26.697425      95 common.go:193] "parent task: Done" task="Bootstrap"
E0804 21:21:26.697655      95 init_oracle.go:216] "CDB provisioning DONE"
I0804 21:21:26.699758      23 dbdaemon_proxy.go:403] "proxy/ProxyRunInitOracle: DONE"
```

This change sets the log level to the default Info verbosity, in line with the other success messages.  It shouldn't affect functionality, but rather just the levels displayed in logs.