### PR TITLE
Increase default timeout for dbdaemon calls

### DIFF
--- a/oracle/pkg/agents/common/dbdaemonlib.go
+++ b/oracle/pkg/agents/common/dbdaemonlib.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	// CallTimeout can be set via a flag by the program importing the library.
-	CallTimeout = 5 * time.Minute
+	CallTimeout = 15 * time.Minute
 )
 
 // withTimeout returns a context with a default timeout if the input context has no timeout.


### PR DESCRIPTION
dbdaemon, among other things, runs SQL statements inside an Oracle database, and such statements can be time-consuming, especially on systems with slow I/O.  For example: creating pluggable databases or resetlogs operations.  

I considered setting the CallTimeout variable in callers like init_oracle.go, but ended up opting for changing the default because the variable is persistent, and could have unpredictable results depending on the order in which operations were called.