### PR TITLE
Validate CDBName in the operator CRD

### DIFF
--- a/oracle/api/v1alpha1/instance_types.go
+++ b/oracle/api/v1alpha1/instance_types.go
@@ -62,8 +62,11 @@ type InstanceSpec struct {
 
 	// CDBName is the intended name of the CDB attribute. If the CDBName is
 	// different from the original name (with which the CDB was created) the
-	// CDB will be renamed.
+	// CDB will be renamed.  The CDBName should meet Oracle SID requirements:
+	// uppercase, alphanumeric, max 8 characters, and not start with a number.
 	// +optional
+	// +kubebuilder:validation:MaxLength=8
+	// +kubebuilder:validation:Pattern=`[A-Z][A-Z0-9]*`
 	CDBName string `json:"cdbName,omitempty"`
 
 	// DBUniqueName represents a unique database name that would be

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
@@ -105,6 +105,7 @@ spec:
                 description: CDBName is the intended name of the CDB attribute. If
                   the CDBName is different from the original name (with which the
                   CDB was created) the CDB will be renamed.
+                pattern: ^[A-Z][A-Z0-9]{0,7}$
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
@@ -102,10 +102,13 @@ spec:
                     type: string
                 type: object
               cdbName:
-                description: CDBName is the intended name of the CDB attribute. If
+                description: 'CDBName is the intended name of the CDB attribute. If
                   the CDBName is different from the original name (with which the
-                  CDB was created) the CDB will be renamed.
-                pattern: ^[A-Z][A-Z0-9]{0,7}$
+                  CDB was created) the CDB will be renamed.  The CDBName should meet
+                  Oracle SID requirements: uppercase, alphanumeric, max 8 characters,
+                  and not start with a number.'
+                maxLength: 8
+                pattern: '[A-Z][A-Z0-9]*'
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -1867,10 +1867,13 @@ spec:
                     type: string
                 type: object
               cdbName:
-                description: CDBName is the intended name of the CDB attribute. If
+                description: 'CDBName is the intended name of the CDB attribute. If
                   the CDBName is different from the original name (with which the
-                  CDB was created) the CDB will be renamed.
-                pattern: ^[A-Z][A-Z0-9]{0,7}$
+                  CDB was created) the CDB will be renamed.  The CDBName should meet
+                  Oracle SID requirements: uppercase, alphanumeric, max 8 characters,
+                  and not start with a number.'
+                maxLength: 8
+                pattern: '[A-Z][A-Z0-9]*'
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -1870,7 +1870,6 @@ spec:
                 description: CDBName is the intended name of the CDB attribute. If
                   the CDBName is different from the original name (with which the
                   CDB was created) the CDB will be renamed.
-                pattern: ^[A-Z][A-Z0-9]{0,7}$
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -1870,6 +1870,7 @@ spec:
                 description: CDBName is the intended name of the CDB attribute. If
                   the CDBName is different from the original name (with which the
                   CDB was created) the CDB will be renamed.
+                pattern: ^[A-Z][A-Z0-9]{0,7}$
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is


### PR DESCRIPTION
The CDBName parameter, among other things, represents the system identifier (SID) of the Oracle container database (CDB).  As per https://docs.oracle.com/en/database/oracle/oracle-database/19/unxar/administering-oracle-database.html#GUID-B8418A24-2F0B-4394-9C6D-29A8CA1DFEEB

    Syntax: A string of numbers and letters that must begin with a letter. Oracle recommends a maximum of 8 characters for system identifiers

Additionally, I've observed that a lowercase CDBName database creation using El Carro results in instance creation failures with ORA-27300 errors stemming from a mix hc_mydb.dat and hc_MYDB.dat files in $ORACLE_HOME/dbs.  More details: https://support.oracle.com/rs?type=doc&id=1664332.1

So this change enforces these requirements: one uppercase character, plus up to 7 uppercase or numeric characters.  Symbols are not permitted.