### PR TITLE
Anchor regex for CDBName

### DIFF
--- a/oracle/api/v1alpha1/instance_types.go
+++ b/oracle/api/v1alpha1/instance_types.go
@@ -66,7 +66,7 @@ type InstanceSpec struct {
 	// uppercase, alphanumeric, max 8 characters, and not start with a number.
 	// +optional
 	// +kubebuilder:validation:MaxLength=8
-	// +kubebuilder:validation:Pattern=`[A-Z][A-Z0-9]*`
+	// +kubebuilder:validation:Pattern=^[A-Z][A-Z0-9]*$
 	CDBName string `json:"cdbName,omitempty"`
 
 	// DBUniqueName represents a unique database name that would be

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
@@ -108,7 +108,7 @@ spec:
                   Oracle SID requirements: uppercase, alphanumeric, max 8 characters,
                   and not start with a number.'
                 maxLength: 8
-                pattern: '[A-Z][A-Z0-9]*'
+                pattern: ^[A-Z][A-Z0-9]*$
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is

--- a/oracle/controllers/configcontroller/config_controller_test.go
+++ b/oracle/controllers/configcontroller/config_controller_test.go
@@ -116,7 +116,7 @@ func createInstances() {
 				Namespace: Namespace,
 			},
 			Spec: v1alpha1.InstanceSpec{
-				CDBName: fmt.Sprintf("MYDB-%d", i),
+				CDBName: fmt.Sprintf("MYDB%d", i),
 			},
 		}
 		Expect(k8sClient.Create(context.Background(), instance)).Should(Succeed())

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -1873,7 +1873,7 @@ spec:
                   Oracle SID requirements: uppercase, alphanumeric, max 8 characters,
                   and not start with a number.'
                 maxLength: 8
-                pattern: '[A-Z][A-Z0-9]*'
+                pattern: ^[A-Z][A-Z0-9]*$
                 type: string
               characterSet:
                 description: CharacterSet used to create a database (the default is


### PR DESCRIPTION
In PR #228 we added validation for the CDBName instance parameter.  However
the regex was missing line start and end anchors (^ and $), meaning that it
would match partial subscrings.  So a CDBName like `1DB` would have been
accepted when it should have errored out.

Adding the anchors here, and also removing the backquotes for
consistency with other patterns, and since none of these characters need
quoting in YaML.

I took the liberty to create testscases with a few cdbName values:

```
$ for file in *.yaml; do grep -H cdbName $file && kubectl apply -f $file; done
instance-8char.yaml:  cdbName: A2345678
instance.oracle.db.anthosapis.com/mydb configured
instance-a.yaml:  cdbName: A
instance.oracle.db.anthosapis.com/mydb configured
instance-db1.yaml:  cdbName: DB1
instance.oracle.db.anthosapis.com/mydb configured
instance-lowercase.yaml:  cdbName: lowercase
The Instance "mydb" is invalid: spec.cdbName: Invalid value:
"lowercase": spec.cdbName in body should be at most 8 chars long
instance-number.yaml:  cdbName: 1DB
The Instance "mydb" is invalid: spec.cdbName: Invalid value: "1DB":
spec.cdbName in body should match '^[A-Z][A-Z0-9]*$'
instance-symbols.yaml:  cdbName: DB#1
The Instance "mydb" is invalid: spec.cdbName: Invalid value: "DB#1":
spec.cdbName in body should match '^[A-Z][A-Z0-9]*$'
instance-toolong.yaml:  cdbName: OVER8CHARS
The Instance "mydb" is invalid: spec.cdbName: Invalid value:
"OVER8CHARS": spec.cdbName in body should be at most 8 chars long
```