### PR TITLE
Remove patchstorage in image build post step

### DIFF
--- a/oracle/build/dbimage/install-oracle.sh
+++ b/oracle/build/dbimage/install-oracle.sh
@@ -299,6 +299,8 @@ cleanup_post_success() {
     rm -rf "${OHOME}/install/pilot" &&
     # Support tools
     rm -rf "${OHOME}/suptools" &&
+    # Previous patches binaries
+    rm -rf "${OHOME}/.patch_storage" &&
     # Temp location
     rm -rf /tmp/* &&
     # Install files


### PR DESCRIPTION
This directory stores the original binaries after an image is
successfully patched in order to allow rollback. We do not support
rollback via OPatch so these old binaries are unneeded.

Change-Id: I3fad1f90692c9c83a44aaff04f609da300ff1232