### PR TITLE
Always pull Operator image

### DIFF
--- a/oracle/config/manager/manager.yaml
+++ b/oracle/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - --enable-leader-election
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         resources:
           limits:

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -3351,6 +3351,7 @@ spec:
         command:
         - /manager
         image: gcr.io/elcarro/oracle.db.anthosapis.com/operator:latest
+        imagePullPolicy: Always
         name: manager
         resources:
           limits:


### PR DESCRIPTION
The default imagePullPolicy is IfNotPresent, images are only pulled if not already present on the kubelet. Changing the policy to Always ensures that we always pull the image if the digest of the image on the kubelet is different from the one on the image repo. This is useful for dev environments where the same image tag is reused. I've seen instances where my latest operator image did not get pulled because Kubernetes compared image tags instead of digests.

See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.

Change-Id: Ic89e4e218a97a47dec7254789f18b68908cb383b