### PR TITLE
Prevent the password of SYS and SYSTEM password leak

### DIFF
--- a/oracle/build/dbimage/install-oracle-18c-xe.sh
+++ b/oracle/build/dbimage/install-oracle-18c-xe.sh
@@ -44,8 +44,10 @@ SKIP_VALIDATIONS=FALSE" > /etc/sysconfig/oracle-xe-18c.conf
 }
 
 create_cdb() {
+  set +x
   local syspass="$(openssl rand -base64 16 | tr -dc a-zA-Z0-9)"
   (echo "${syspass}"; echo "${syspass}";) | /etc/init.d/oracle-xe-18c configure
+  set -x
 }
 
 set_file_ownership() {

--- a/oracle/build/dbimage/install-oracle.sh
+++ b/oracle/build/dbimage/install-oracle.sh
@@ -253,6 +253,7 @@ enable_unified_auditing() {
 }
 
 create_cdb() {
+  set +x
   local syspass="$(openssl rand -base64 16 | tr -dc a-zA-Z0-9)"
   sudo -u oracle "${OHOME}/bin/dbca" \
     -silent \
@@ -272,6 +273,7 @@ create_cdb() {
     -recoveryAreaDestination /u01/app/oracle/fast_recovery_area \
     -sysPassword "${syspass}" \
     -systemPassword "${syspass}"
+  set -x
 }
 
 set_environment() {


### PR DESCRIPTION
Setting the tracing `-x` flag in Bash causes all interpolated shell commands to be printed into stdout including the randomly generated SYS and SYSTEM passwords. This may let readers of image build logs gain elevated access to databases provisioned by El Carro.

This PR temporarily disables the bash tracing for the duration of the CDB creation, then resumes tracing again.