### PR TITLE
Fixes hang on timeout, tweak cron tests

### DIFF
--- a/common/controllers/cronanything_controller.go
+++ b/common/controllers/cronanything_controller.go
@@ -648,7 +648,13 @@ func getResourceName(ca cronanything.CronAnything, scheduleTime time.Time) strin
 func getScheduleTimes(ca cronanything.CronAnything, now time.Time) ([]time.Time, time.Time, error) {
 	schedule, err := cron.ParseStandard(ca.CronAnythingSpec().Schedule)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("unable to parse schedule string: %v", err)
+		// Allow Full Cron formats if its invalid as a standard cron format.
+		var err2 error
+		schedule, err2 = cron.Parse(ca.CronAnythingSpec().Schedule)
+		if err2 != nil {
+			return nil, time.Time{}, fmt.Errorf("unable to parse schedule string: %v", err)
+		}
+		err = nil
 	}
 
 	var scheduleTimes []time.Time

--- a/oracle/controllers/backupschedulecontroller/functest/BUILD.bazel
+++ b/oracle/controllers/backupschedulecontroller/functest/BUILD.bazel
@@ -1,6 +1,7 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//oracle:scripts/ginkgo_test.bzl", "ginkgo_test")
 
-go_test(
+# gazelle:map_kind go_test ginkgo_test //oracle:scripts/ginkgo_test.bzl
+ginkgo_test(
     name = "functest_test",
     size = "medium",
     srcs = ["backupschedule_controller_functional_test.go"],


### PR DESCRIPTION
Ginkgo function panic on failure so waitgroup.Done() never happens and
the entire test hangs. Instead we should let GinkgoRecover recover the
function and then call waitgroup.Done() from the caller that recovered.
Now the test should resolve as pass/fail within 30s.

Also tweak cronanything to accept subminute schedules and clamp down
timings. Running for 100 runs new run stats are:
//oracle/controllers/backupschedulecontroller/functest:functest_test
PASSED in 28.5s
  Stats over 100 runs: max = 28.5s, min = 23.1s, avg = 25.3s, dev = 1.0s

Change-Id: I7468c99199a4a93a359d2b2f0afa2d8c00eb3ba8