### PR TITLE
Assorted cleanup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,9 +133,9 @@ filegroup(
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )""",
-    sha256 = "fb13a93a800389029b06fcc74ab6a3b969ff74178252709a040e4756251739d2",
+    sha256 = "6d9f0a6ab0119c5060799b4b8cbd0a030562da70b7ad4125c218eaf028c6cc28",
     strip_prefix = "kubebuilder",
-    urls = ["https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-1.19.2-linux-amd64.tar.gz"],
+    urls = ["https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-1.24.2-linux-amd64.tar.gz"],
 )
 
 http_archive(

--- a/oracle/cmd/logging/logging_main.go
+++ b/oracle/cmd/logging/logging_main.go
@@ -232,7 +232,7 @@ func queryDB(ctx context.Context, query string) (string, error) {
 	}
 	defer closeConn()
 
-	resp, err := dbdClient.RunSQLPlusFormatted(ctx, &dbdpb.RunSQLPlusCMDRequest{Commands: []string{query}, Suppress: true, Quiet: true})
+	resp, err := dbdClient.RunSQLPlusFormatted(ctx, &dbdpb.RunSQLPlusCMDRequest{Commands: []string{query}, Suppress: false, Quiet: true})
 	if err != nil {
 		return "", err
 	}

--- a/oracle/controllers/testhelpers/grpcmocks.go
+++ b/oracle/controllers/testhelpers/grpcmocks.go
@@ -515,6 +515,8 @@ func (cli *FakeDatabaseClient) RemoveMethodToError(method string) {
 }
 
 func (cli *FakeDatabaseClient) getMethodRespErr(method string) (interface{}, error) {
+	cli.lock.Lock()
+	defer cli.lock.Unlock()
 	var err error
 	var resp interface{}
 	if cli.methodToResp != nil {

--- a/oracle/pkg/database/provision/bootstrap_database_task.go
+++ b/oracle/pkg/database/provision/bootstrap_database_task.go
@@ -105,7 +105,7 @@ func (task *BootstrapTask) setParameters(ctx context.Context) error {
 	retry := 0
 	var err error
 	for ; retry < startupRetries; retry++ {
-		_, err := task.dbdClient.BounceDatabase(ctx, &dbdpb.BounceDatabaseRequest{
+		_, err = task.dbdClient.BounceDatabase(ctx, &dbdpb.BounceDatabaseRequest{
 			Operation:    dbdpb.BounceDatabaseRequest_STARTUP,
 			DatabaseName: task.db.GetDatabaseName(),
 			Option:       "nomount",


### PR DESCRIPTION
Fixes some logging issues, reducing the number of lines logged per query
and supressing some queries that were not respecting the suppress rules.

Fixes a datarace in our mocks that rarely happens.

It also adds some additional locking around BounceDatabase to avoid
running queries when we know the database is transitioning between
start/stop.

Updates kubebuilder-tools to k8s 1.24 to match our k8s library versions.
This also requires a fix for exiting our controllers before shutting
down the testenv.

Change-Id: Ia532f974d442d0925f9b2fd2a20c9956bf36afaa