### PR TITLE
Fixup containerized build

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -227,7 +227,7 @@ buildah-push-all-containerized:
 		--mount=type=bind,src=$(shell readlink -f ~/.cache/bazel),dst=/root/.cache/bazel \
 		--mount=type=bind,src=$(shell readlink -f ~/.config/),dst=/root/.config/ \
 		gcr.io/k8s-testimages/kubekins-e2e:latest-master \
-		/bin/sh -c "gcloud auth configure-docker --quiet && cd /workspace/code/oracle && make buildah-push-all && rm /workspace/code/bazel-*"
+		/bin/sh -c "gcloud auth configure-docker --quiet && /workspace/code/oracle/scripts/install_prow_deps.sh && cd /workspace/code/oracle && make buildah-push-all && rm /workspace/code/bazel-*"
 
 
 # Install all the required dependencies for prow.


### PR DESCRIPTION
We did not prepare the environment correctly so it was out of sync with prow and other environments using the same container. This adds in the call the install_prow_deps.sh to ensure it is correct.

Change-Id: I97cf5ea9393e9eedb25c30573bac454f3d8d9836