### PR TITLE
Allow setting DEFERRED database parameters.

### DIFF
--- a/oracle/controllers/config_agent_helpers.go
+++ b/oracle/controllers/config_agent_helpers.go
@@ -539,6 +539,9 @@ func SetParameter(ctx context.Context, dbClientFactory DatabaseClientFactory, r 
 		command = fmt.Sprintf("%s scope=spfile", command)
 		isStatic = true
 	}
+	if paramType == "DEFERRED" {
+		command = fmt.Sprintf("%s deferred", command)
+	}
 
 	_, err = dbClient.RunSQLPlus(ctx, &dbdpb.RunSQLPlusCMDRequest{
 		Commands: []string{command},


### PR DESCRIPTION
Formerly, attempts to set parameters with ISSYS_MODIFIABLE = DEFERRED would have resulted in the error "ORA-02096: specified initialization parameter is not modifiable with this option". Example parameter: RECYCLEBIN.