### PR TITLE
Fix flaky instance deletion test

### DIFF
--- a/oracle/controllers/inttest/instancetest/instance_test.go
+++ b/oracle/controllers/inttest/instancetest/instance_test.go
@@ -222,7 +222,7 @@ func deleteInstance(ctx context.Context, instanceName, namespace string) {
 			Name:      instanceName,
 		},
 	}
-	testhelpers.K8sDeleteWithRetry(k8sEnv.K8sClient, ctx, client.ObjectKey{Name: instanceName, Namespace: namespace}, instance)
+	testhelpers.K8sDeleteWithRetryNoWait(k8sEnv.K8sClient, ctx, client.ObjectKey{Name: instanceName, Namespace: namespace}, instance)
 }
 
 func deleteDatabase(ctx context.Context, databaseName, namespace string) {


### PR DESCRIPTION
In many cases, envtest.K8sDeleteWithRetry() will time out before an instance gets deleted. Switch to using envtest.K8sDeleteWithRetryNoWait() and check that the Instance was deleted in the core test assertion instead of in the helper method.

Change-Id: Iae8966b7a4e2be14bde0e8ef4a73d21322fd324b