### PR TITLE
Limit CIDR ranges for GKE Clusters

### DIFF
--- a/oracle/scripts/integration_test_cluster/create_integration_test_cluster.sh
+++ b/oracle/scripts/integration_test_cluster/create_integration_test_cluster.sh
@@ -40,7 +40,12 @@ time gcloud beta container clusters create "${PROW_CLUSTER}" \
 --project="${PROW_PROJECT}" \
 --scopes "gke-default,compute-rw,cloud-platform,https://www.googleapis.com/auth/dataaccessauditlogging" \
 --enable-gcfs \
---workload-pool="${PROW_PROJECT}.svc.id.goog"
+--workload-pool="${PROW_PROJECT}.svc.id.goog" \
+--enable-ip-alias \
+--create-subnetwork name="${PROW_CLUSTER}-subnet",range=/20 \
+--cluster-ipv4-cidr /16 \
+--services-ipv4-cidr /20
+
 
 gcloud container clusters get-credentials ${PROW_CLUSTER} --zone ${PROW_CLUSTER_ZONE} --project ${PROW_PROJECT}
 kubectl config set-context gke_${PROW_PROJECT}_${PROW_CLUSTER_ZONE}_${PROW_CLUSTER}


### PR DESCRIPTION
This changes makes new cluster support up to 256 nodes, up to 110 pods per nodes and up to 4096 services across the entire cluster. For reference, see https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips and https://cloud.google.com/architecture/gke-address-management-options#determining_the_pod_cidr_block_size

Change-Id: I0e7460c55c46677180fb0f2ef89bcc2720dd9e01