### PR TITLE
Fix backupschedule spec propagation

### DIFF
--- a/common/controllers/backupschedule_controller.go
+++ b/common/controllers/backupschedule_controller.go
@@ -204,7 +204,8 @@ func (r *BackupScheduleReconciler) updateCron(backupSchedule v1alpha1.BackupSche
 		freshCron.CronAnythingSpec().Schedule = backupSchedule.BackupScheduleSpec().Schedule
 		freshCron.CronAnythingSpec().Template.Raw = backupBytes
 		freshCron.CronAnythingSpec().TriggerDeadlineSeconds = backupSchedule.BackupScheduleSpec().StartingDeadlineSeconds
-		return r.cronAnythingCtrl.Update(freshCron)
+
+		return r.Client.Update(context.TODO(), freshCron)
 	})
 }
 

--- a/common/controllers/backupschedule_controller_test.go
+++ b/common/controllers/backupschedule_controller_test.go
@@ -596,7 +596,7 @@ func (f *mockCronAnythingControl) Create(ns string, name string, cas v1alpha1.Cr
 func (f *mockCronAnythingControl) Get(key client.ObjectKey) (v1alpha1.CronAnything, error) {
 	return f.get(key)
 }
-func (f *mockCronAnythingControl) Update(cron v1alpha1.CronAnything) error {
+func (f *mockCronAnythingControl) UpdateStatus(cron v1alpha1.CronAnything) error {
 	return f.update(cron)
 }
 

--- a/common/controllers/cronanything_controller.go
+++ b/common/controllers/cronanything_controller.go
@@ -56,7 +56,7 @@ type resourceResolver interface {
 // cronAnythingControl provides methods for getting and updating CronAnything resources.
 type cronAnythingControl interface {
 	Get(key client.ObjectKey) (cronanything.CronAnything, error)
-	Update(ca cronanything.CronAnything) error
+	UpdateStatus(ca cronanything.CronAnything) error
 	Create(ns string, name string, cas cronanything.CronAnythingSpec, owner cronanything.BackupSchedule) error
 }
 
@@ -377,7 +377,7 @@ func (r *ReconcileCronAnything) updateCronAnythingStatus(name, namespace string,
 		}
 
 		updateFunc(instance.CronAnythingStatus())
-		return r.cronanythingControl.Update(instance)
+		return r.cronanythingControl.UpdateStatus(instance)
 	})
 }
 

--- a/common/controllers/cronanything_controller_test.go
+++ b/common/controllers/cronanything_controller_test.go
@@ -1372,7 +1372,7 @@ func (r *fakeCronAnythingControl) Get(key client.ObjectKey) (cronanything.CronAn
 	return r.getCronAnything, r.getError
 }
 
-func (r *fakeCronAnythingControl) Update(ca cronanything.CronAnything) error {
+func (r *fakeCronAnythingControl) UpdateStatus(ca cronanything.CronAnything) error {
 	r.updateCronAnything = ca
 	return r.updateError
 }

--- a/oracle/controllers/cronanythingcontroller/operations.go
+++ b/oracle/controllers/cronanythingcontroller/operations.go
@@ -21,11 +21,8 @@ func (r *RealCronAnythingControl) Get(key client.ObjectKey) (commonv1alpha1.Cron
 	return ca, err
 }
 
-func (r *RealCronAnythingControl) Update(ca commonv1alpha1.CronAnything) error {
-	if err := r.Client.Status().Update(context.TODO(), ca.(*v1alpha1.CronAnything)); err != nil {
-		return err
-	}
-	return r.Client.Update(context.TODO(), ca.(*v1alpha1.CronAnything))
+func (r *RealCronAnythingControl) UpdateStatus(ca commonv1alpha1.CronAnything) error {
+	return r.Client.Status().Update(context.TODO(), ca.(*v1alpha1.CronAnything))
 }
 
 func (r *RealCronAnythingControl) Create(ns string, name string, cas commonv1alpha1.CronAnythingSpec, owner commonv1alpha1.BackupSchedule) error {


### PR DESCRIPTION
This change fixes an issue that was preventing updates to backupschedule specs from getting propagated to CronAnything specs. For some reason, updating an entire CronAnything object in operations.go after updating the status of that same CronAnything object was causing new updates to the spec to disappear. To avoid this issue, we directly update CronAnything specs from backupschedule_controller.go.

b/251830497

Change-Id: I3a5afd914fa50481ebbec4e350234aad86dadc2f