### PR TITLE
Tweaks for test flakes

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -439,9 +439,9 @@ func (r *InstanceReconciler) reconcileDatabaseInstance(ctx context.Context, inst
 	dbInstanceCond := k8s.FindCondition(inst.Status.Conditions, k8s.DatabaseInstanceReady)
 	log.Info("reconciling database instance: ", "instanceReadyCond", instanceReadyCond, "dbInstanceCond", dbInstanceCond)
 
-	// reconcile database only when instance is ready
+	// reconcile database only when instance is ready, but requeue.
 	if !k8s.ConditionStatusEquals(instanceReadyCond, v1.ConditionTrue) {
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	isImageSeeded, err := r.isImageSeeded(ctx, inst, log)

--- a/oracle/pkg/database/provision/common.go
+++ b/oracle/pkg/database/provision/common.go
@@ -386,6 +386,8 @@ func RemoveConfigFileLinks(OracleHome, CDBName string) error {
 			if err := os.Remove(link); err != nil {
 				return fmt.Errorf("RemoveConfigFileLinks: unable to delete existing link %s: %v", link, err)
 			}
+		} else {
+			klog.Infof("RemoveConfigFileLinks: No prior file to cleanup: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously we would return that we do not need any further reconciling while waiting for the instance to be ready in the instance reconciler if the sts was complete but the database was not yet started.

Instead lets be sure to ask to be requeued a bit later.

Also log errors in removing symlinks as we see this flaking very rarely but its unclear why the cleanup didnt run, whether it really was not found or a different retriable error was thrown by the Lstat operation.

Change-Id: I3e01e1f08c994cd2b66d6af4aae61fc09e8f657d