### PR TITLE
Ensure monitoring pod is removed with instance

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -398,6 +399,18 @@ func lroBootstrapCDBOperationID(instance v1alpha1.Instance) string {
 
 func (r *InstanceReconciler) reconcileInstanceDeletion(ctx context.Context, req ctrl.Request, log logr.Logger) (ctrl.Result, error) {
 	log.Info("Deleting Instance...", "InstanceName", req.NamespacedName.Name)
+
+	// NOTE: must be kept in sync with reconcileMonitoring
+	var monitor appsv1.Deployment
+	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: fmt.Sprintf("%s-monitor", req.Name)}, &monitor); err == nil {
+		if err := r.Delete(ctx, &monitor); err != nil {
+			log.Error(err, "failed to delete monitoring deployment", "InstanceName", req.Name, "MonitorDeployment", monitor.Name)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	} else if !apierrors.IsNotFound(err) { // retry on other errors.
+		return ctrl.Result{}, err
+	}
 
 	var inst v1alpha1.Instance
 	if err := r.Get(ctx, req.NamespacedName, &inst); err != nil {


### PR DESCRIPTION
Previously we were relying on owner's references for cleanup but these do not actually ensure any cleanup is done when the owner is destroyed. Instead we need to take action to delete these deployments during the instance deletion steps similar to databases.

bug: 259996978
Change-Id: I47be39b7faf5fe4ce106ddd1f0ee8cb74fd6ec4b