### PR TITLE
Remove infinite loop from parameter update state machine

### DIFF
--- a/oracle/controllers/common.go
+++ b/oracle/controllers/common.go
@@ -44,12 +44,13 @@ const (
 	RestoreInProgress = "Restore" + StatusInProgress
 	CreateInProgress  = "Create" + StatusInProgress
 
-	PITRLabel               = "pitr"
-	IncarnationLabel        = "incarnation"
-	ParentIncarnationLabel  = "parent-incarnation"
-	SCNAnnotation           = "scn"
-	TimestampAnnotation     = "timestamp"
-	DatabaseImageAnnotation = "database-image"
+	PITRLabel                   = "pitr"
+	IncarnationLabel            = "incarnation"
+	ParentIncarnationLabel      = "parent-incarnation"
+	SCNAnnotation               = "scn"
+	TimestampAnnotation         = "timestamp"
+	DatabaseImageAnnotation     = "database-image"
+	ParameterUpdateStateMachine = "ParameterUpdateStateMachine"
 )
 
 var (

--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -165,15 +165,10 @@ func (r *InstanceReconciler) Reconcile(_ context.Context, req ctrl.Request) (_ c
 		return r.standbyStateMachine(ctx, &inst, log)
 	}
 
-	// If the instance and database is ready, we can set the instance parameters
-	if k8s.ConditionStatusEquals(instanceReadyCond, v1.ConditionTrue) &&
-		k8s.ConditionStatusEquals(dbInstanceCond, v1.ConditionTrue) && inst.Spec.Parameters != nil {
-		log.Info("instance and db is ready, setting instance parameters")
-
-		if result, err := r.setInstanceParameterStateMachine(ctx, req, inst, log); err != nil {
-			return result, err
-		}
+	if result, err := r.parameterUpdateStateMachine(ctx, req, inst, log); err != nil {
+		return result, err
 	}
+
 	// If the instance and database is ready, we can set the instance parameters
 	if k8s.ConditionStatusEquals(instanceReadyCond, v1.ConditionTrue) &&
 		k8s.ConditionStatusEquals(dbInstanceCond, v1.ConditionTrue) && (inst.Spec.EnableDnfs != inst.Status.DnfsEnabled) {

--- a/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
+++ b/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
@@ -149,7 +149,7 @@ var _ = Describe("ParameterUpdate", func() {
 				})
 
 			// Verify the instance transitions to ParameterUpdateRollback state due to database unable to restart.
-			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.ParameterUpdateRollback, 5*time.Minute)
+			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.ParameterUpdateRollbackInProgress, 5*time.Minute)
 
 			// Wait until the instance settles into "Ready" again
 			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.CreateComplete, 20*time.Minute)

--- a/oracle/pkg/k8s/condition.go
+++ b/oracle/pkg/k8s/condition.go
@@ -74,8 +74,9 @@ const (
 	ExportInProgress = "ExportInProgress"
 	ExportPending    = "ExportPending"
 
-	ParameterUpdateInProgress = "ParameterUpdateInProgress"
-	ParameterUpdateRollback   = "ParameterUpdateRollback"
+	ParameterUpdateInProgress         = "ParameterUpdateInProgress"
+	ParameterUpdateComplete           = "ParameterUpdateComplete"
+	ParameterUpdateRollbackInProgress = "ParameterUpdateRollbackInProgress"
 
 	StandbyDRInProgress                     = "StandbyDRInProgress"
 	StandbyDRVerifyCompleted                = "StandbyDRVerifyCompleted"


### PR DESCRIPTION
Avoid infinite loops in the parameter update state machine and instead synchronize the state machine with the reconcile loops of the instance controller.

b/255642316

Change-Id: Ic5d36c98c8fdb3dea7391fb0145c5f89bbe4034b