### PR TITLE
Fixup context handling in controllers

### DIFF
--- a/oracle/controllers/backupcontroller/backup_controller.go
+++ b/oracle/controllers/backupcontroller/backup_controller.go
@@ -46,6 +46,7 @@ var (
 	statusCheckInterval  = time.Minute
 	msgSep               = "; "
 	timeNow              = time.Now
+	reconcileTimeout     = 3 * time.Minute
 )
 
 // BackupReconciler reconciles a Backup object.
@@ -122,8 +123,9 @@ func (r *BackupReconciler) updateBackupStatus(ctx context.Context, backup *v1alp
 	return r.BackupCtrl.UpdateStatus(backup)
 }
 
-func (r *BackupReconciler) Reconcile(_ context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
-	ctx := context.Background()
+func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
 	log := r.Log.WithValues("Backup", req.String())
 
 	log.Info("reconciling backup requests")

--- a/oracle/controllers/exportcontroller/export_controller.go
+++ b/oracle/controllers/exportcontroller/export_controller.go
@@ -97,10 +97,10 @@ var (
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is a generic reconcile function for Export resources.
-func (r *ExportReconciler) Reconcile(_ context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
+func (r *ExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
 	log := r.Log.WithValues("Export", req.NamespacedName)
 	log.Info("reconciling export")
-	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 
 	exp := &v1alpha1.Export{}

--- a/oracle/controllers/importcontroller/import_controller.go
+++ b/oracle/controllers/importcontroller/import_controller.go
@@ -96,10 +96,10 @@ var (
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is a generic reconcile function for Import resources.
-func (r *ImportReconciler) Reconcile(_ context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
+func (r *ImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
 	log := r.Log.WithValues("Import", req.NamespacedName)
 	log.Info("reconciling import")
-	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 
 	imp := &v1alpha1.Import{}

--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -91,10 +91,12 @@ const (
 	DatabaseInstanceReadyTimeoutUnseeded = 60 * time.Minute // 60 minutes because it can take 50+ minutes to create an unseeded CDB
 	dateFormat                           = "20060102"
 	DefaultStsPatchingTimeout            = 25 * time.Minute
+	reconcileTimeout                     = 3 * time.Minute
 )
 
-func (r *InstanceReconciler) Reconcile(_ context.Context, req ctrl.Request) (_ ctrl.Result, respErr error) {
-	ctx := context.Background()
+func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, respErr error) {
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
 	log := r.Log.WithValues("Instance", req.NamespacedName)
 
 	log.Info("reconciling instance")

--- a/oracle/controllers/instancecontroller/instance_controller_patching.go
+++ b/oracle/controllers/instancecontroller/instance_controller_patching.go
@@ -301,7 +301,7 @@ func isStatefulSetPatchingRequired(currentImages map[string]string, newImages ma
 }
 
 func (r *InstanceReconciler) startPatchingBackup(req ctrl.Request, ctx context.Context, inst *v1alpha1.Instance, log logr.Logger) (ctrl.Result, error) {
-	backupID, err := r.prePatchBackup(*inst)
+	backupID, err := r.prePatchBackup(ctx, *inst)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -392,7 +392,7 @@ func cloneMap(source map[string]string) map[string]string {
 	return clone
 }
 
-func (r *InstanceReconciler) prePatchBackup(inst v1alpha1.Instance) (string, error) {
+func (r *InstanceReconciler) prePatchBackup(ctx context.Context, inst v1alpha1.Instance) (string, error) {
 	// do the same for db instance
 	// TODO: these snapshots should get cleaned up at some point
 
@@ -402,7 +402,6 @@ func (r *InstanceReconciler) prePatchBackup(inst v1alpha1.Instance) (string, err
 
 	// FIXME: this should not be hard coded
 	vsc := "csi-gce-pd-snapshot-class"
-	ctx := context.Background()
 	log := r.Log.WithValues("Instance", inst.Name)
 
 	for _, diskSpec := range inst.Spec.Disks {

--- a/oracle/controllers/inttest/instancetest/instance_test.go
+++ b/oracle/controllers/inttest/instancetest/instance_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Instance and Database provisioning", func() {
 				updatedInstance := &v1alpha1.Instance{}
 				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: firstInstanceName, Namespace: namespace}, updatedInstance)).Should(Succeed())
 				return updatedInstance.Status.DatabaseNames, nil
-			}, 60*time.Second, 5*time.Second).Should(BeEmpty())
+			}, 2*time.Minute, 5*time.Second).Should(BeEmpty())
 
 			By("Checking that only PVCs for the first instance are retained")
 			deleteInstance(ctx, firstInstanceName, namespace)

--- a/oracle/controllers/testhelpers/envtest.go
+++ b/oracle/controllers/testhelpers/envtest.go
@@ -1406,7 +1406,9 @@ func K8sWaitForUpdate(k8sClient client.Client,
 // k8s service account <projectId>.svc.id.goog[<NAMESPACE>/default]
 // and google service account.
 func SetupServiceAccountBindingBetweenGcpAndK8s(k8sEnv K8sOperatorEnvironment) {
-	Expect(retry.OnError(retry.DefaultBackoff, func(error) bool { return true }, func() error {
+	longerBackoff := retry.DefaultBackoff
+	longerBackoff.Steps = 6 // Try a couple more times as there is lots of contention
+	Expect(retry.OnError(longerBackoff, func(error) bool { return true }, func() error {
 		cmd := exec.Command("gcloud", "iam",
 			"service-accounts", "add-iam-policy-binding",
 			"--role=roles/iam.workloadIdentityUser",


### PR DESCRIPTION
This ensures we derive our contexts from the original Reconcile() context

Also make tweaks for flakes: the timeout for database deletion which appears may take another minute or two to reconcile during heavy test load. Add another two retries to service account binding which has a lot of contention on test start.

Change-Id: I678bfc94ae3c096a4d1fb32063e51c4e644c8bda