### PR TITLE
Add a retry for GCS upload

### DIFF
--- a/oracle/controllers/testhelpers/envtest.go
+++ b/oracle/controllers/testhelpers/envtest.go
@@ -1136,7 +1136,11 @@ func K8sCopyFromPodOrFail(pod, ns, container, src, dest string) {
 
 // UploadFileOrFail uploads an object to GCS, it raises a ginkgo assert on failure.
 func UploadFileOrFail(localFile, bucket, object string) {
-	Expect(uploadFile(localFile, bucket, object)).NotTo(HaveOccurred())
+	Expect(retry.OnError(retry.DefaultBackoff,
+		func(error) bool { return true },
+		func() error { return uploadFile(localFile, bucket, object) }),
+	).To(Succeed())
+
 }
 
 // uploadFile uploads an object to GCS.


### PR DESCRIPTION
Sometimes we see TLS fail to establish and the connection needs to be retried, this adds a simple retry wrapper to the upload so we dont fail if there is an intermittent issue.

Change-Id: Iffe6fca189d3a820edda84713a404c9ff4681cc6