### PR TITLE
Use a single database connection for monitoring

### DIFF
--- a/common/pkg/monitoring/monitoring.go
+++ b/common/pkg/monitoring/monitoring.go
@@ -342,9 +342,7 @@ func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 	errCount := uint64(0)
 	metricCount := uint64(0)
-
-	// we need to avoid blocking if all workers fail to connect.
-	msQueue := make(chan MetricSet, WORKER_COUNT)
+	msQueue := make(chan MetricSet)
 
 	started := 0
 	var wg sync.WaitGroup
@@ -355,7 +353,7 @@ func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
 			atomic.AddUint64(&errCount, 1)
 			continue
 		}
-		defer db.Close() // closes at end of func, after workers are waited for.
+
 		if err := db.Ping(); err != nil {
 			atomic.AddUint64(&errCount, 1)
 			m.log.Error(err, "failed to connect to database", "collector", i)

--- a/oracle/cmd/monitoring/oracle.go
+++ b/oracle/cmd/monitoring/oracle.go
@@ -15,12 +15,20 @@ type godrorFactory struct {
 	dsn string
 }
 
+var dbSingleton *sql.DB
+
 func (g godrorFactory) Open() (*sql.DB, error) {
-	db, err := sql.Open("godror", g.dsn)
-	if err != nil {
-		err = fmt.Errorf("DB open failed: %w", err)
+	if dbSingleton == nil || dbSingleton.Ping() != nil {
+		if dbSingleton != nil {
+			dbSingleton.Close()
+		}
+		db, err := sql.Open("godror", g.dsn)
+		if err != nil {
+			return nil, fmt.Errorf("DB open failed: %w", err)
+		}
+		dbSingleton = db
 	}
-	return db, err
+	return dbSingleton, nil
 }
 
 func main() {


### PR DESCRIPTION
Testing shows that there appears to be an ODPI based leaked somewhere in the godror driver code. Since we cannot update to later versions that might fix this leak due to other problems, create a singleton driver connection to mitigate leaks.

bug: 259969026
Change-Id: Idb1a4d4182c6668c4a324ad92851d7ef190ba22c