### PR TITLE
Fix: Relink config files only once

### DIFF
--- a/oracle/cmd/init_oracle/init_oracle.go
+++ b/oracle/cmd/init_oracle/init_oracle.go
@@ -134,10 +134,7 @@ func markProvisioned() error {
 	return nil
 }
 
-func reinitUnseededHost(ctx context.Context, oracleHome, cdbName string) error {
-	if err := provision.RelinkConfigFiles(oracleHome, cdbName); err != nil {
-		return err
-	}
+func reinitUnseededHost(ctx context.Context, cdbName string) error {
 	dbdClient, closeConn, err := newDBDClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create database daemon client: %v", err)
@@ -183,7 +180,7 @@ func main() {
 	}
 
 	if *reinit {
-		if err := reinitProvisionedHost(ctx, oracleHome, cdbNameFromImage, *cdbNameFromYaml, version); err != nil {
+		if err := reinitProvisionedHost(ctx, cdbNameFromImage, *cdbNameFromYaml, version); err != nil {
 			klog.ErrorS(err, "Reinit provisioned host failed")
 			os.Exit(consts.DefaultExitErrorCode)
 		}
@@ -217,7 +214,7 @@ func main() {
 	}
 }
 
-func reinitProvisionedHost(ctx context.Context, oracleHome, cdbNameFromImage, cdbNameFromYaml, version string) error {
+func reinitProvisionedHost(ctx context.Context, cdbNameFromImage, cdbNameFromYaml, version string) error {
 	isImageSeeded := cdbNameFromImage != ""
 	if isImageSeeded {
 		klog.InfoS("Reinitialize provisioned seeded database")
@@ -231,7 +228,7 @@ func reinitProvisionedHost(ctx context.Context, oracleHome, cdbNameFromImage, cd
 	} else {
 		klog.InfoS("Reinitialize provisioned unseeded database")
 
-		if err := reinitUnseededHost(ctx, oracleHome, cdbNameFromYaml); err != nil {
+		if err := reinitUnseededHost(ctx, cdbNameFromYaml); err != nil {
 			klog.Error(err, "CDB reinitialization failed")
 			return fmt.Errorf("failed to reinitialize provisioned unseeded database: %v", err)
 		}


### PR DESCRIPTION
RelinkConfigFiles can sometimes get called by both the dbdaemon and init_oracle. Only one call to RelinkConfigFiles is necessary. Having two calls can lead to race conditions.

Delete unused parameter for reinitUnseededHost() function.

b/260762391

Change-Id: I03031bf980c9b1b95239b81af2029a179519088d