### PR TITLE
Add automatic tablespace creation

### DIFF
--- a/oracle/controllers/inttest/datapumptest/datapump_test.go
+++ b/oracle/controllers/inttest/datapumptest/datapump_test.go
@@ -160,8 +160,7 @@ drop user scott cascade;`
 			sql = `alter session set container=pdb1;
 grant unlimited tablespace to scott;
 alter session set current_schema=scott;
-drop table test_table;
-create bigfile tablespace scotty;`
+drop table test_table;`
 			testhelpers.K8sExecuteSqlOrFail(pod, k8sEnv.CPNamespace, sql)
 
 			By("Importing Tables")


### PR DESCRIPTION
This attempts to dump any tablespaces within the dpdmp and schema/users to gather references to tablespaces. It then parses the output sql and creates any tablespaces that appear to be missing.

Failure to create tablespaces automatically is not considered fatal and we will still attempt the import proper afterwards. In this case users must create the tablespaces beforehand still.

bug: 254697198
Change-Id: Id532f02ff687a392400e52179c3baf78e9810403