### PR TITLE
Add prep_seedpdb to image build

### DIFF
--- a/oracle/build/dbimage/install-oracle.sh
+++ b/oracle/build/dbimage/install-oracle.sh
@@ -276,6 +276,14 @@ create_cdb() {
   set -x
 }
 
+prep_seedpdb() {
+  # Consider switching the temp/undo to bigfile and enabling size management of
+  # these at the KRM level.
+
+  # Ensure tempfile can grow to one full datafile 32GB by default.
+  run_sql "alter session set container=pdb\$seed; alter database tempfile '/u01/app/oracle/oradata/${CDB_NAME}/pdbseed/temp01.dbf' autoextend on maxsize unlimited;"
+}
+
 set_environment() {
   source "/home/oracle/${CDB_NAME}.env"
 }
@@ -355,6 +363,7 @@ main() {
   patch_oracle
   if [[ "${CREATE_CDB}" == true ]]; then
     create_cdb
+    prep_seedpdb
     shutdown_oracle
   fi
   chown "${USER}:${GROUP}" /etc/oratab


### PR DESCRIPTION
This also adds a function for making any desired changes to the seed database. We expand the temporary tablespace to ease user experience when importing directly into a freshly built image where additional temp is often required to complete a large import.

bug: 254697360
Change-Id: I2350e5d3f0298a11ab2de07d70a2749ccbfa137c