### PR TITLE
Fix GSM reconciling diff

### DIFF
--- a/oracle/controllers/config_agent_helpers.go
+++ b/oracle/controllers/config_agent_helpers.go
@@ -494,7 +494,7 @@ func UpdateUsers(ctx context.Context, r client.Reader, dbClientFactory DatabaseC
 	}
 
 	for _, u := range toUpdatePwd {
-		klog.InfoS("config_agent_helpers/UpdateUsers", "updating user", u.userName)
+		klog.InfoS("config_agent_helpers/UpdateUsers", "updating user pwd", u.userName)
 		if err := u.updatePassword(ctx, dbClient); err != nil {
 			klog.ErrorS(err, "failed to update user password")
 			foundErr = true

--- a/oracle/controllers/user_repository.go
+++ b/oracle/controllers/user_repository.go
@@ -392,12 +392,6 @@ func newUser(databaseName string, specUser *User) *user {
 			privs = append(privs, upperP)
 		}
 	}
-	var lastVersion string
-	if specUser.PasswordGsmSecretRef != nil {
-		lastVersion = specUser.PasswordGsmSecretRef.Version
-	} else {
-		lastVersion = ""
-	}
 	user := &user{
 		databaseName: strings.ToUpper(databaseName),
 		userName:     strings.ToUpper(specUser.Name),
@@ -407,10 +401,9 @@ func newUser(databaseName string, specUser *User) *user {
 		// Only used for plaintext status diff.
 		curPassword: specUser.LastPassword,
 		specPrivs:   privs,
-		// Empty version is returned if PasswordGsmSecretRef is nil.
-		gsmSecCurVer: lastVersion,
 	}
 	if specUser.PasswordGsmSecretRef != nil {
+		user.gsmSecCurVer = specUser.PasswordGsmSecretRef.LastVersion
 		user.gsmSecNewVer = fmt.Sprintf(gsmSecretStr, specUser.PasswordGsmSecretRef.ProjectId, specUser.PasswordGsmSecretRef.SecretId, specUser.PasswordGsmSecretRef.Version)
 	}
 	return user


### PR DESCRIPTION
The GSM path for passwords would not correctly set the last password resulting in excessive reconciling of the database controller and contact with the database daemon.

bug: 246994099
Change-Id: Id8cb7f4820124ef3f815297bcc570027bea14f29