### PR TITLE
Relax some timeouts on immediate reconciles

### DIFF
--- a/oracle/controllers/inttest/agentpatchingtest/agent_patching_test.go
+++ b/oracle/controllers/inttest/agentpatchingtest/agent_patching_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Agent Patching", func() {
 		instKey := client.ObjectKey{Namespace: k8sEnv.DPNamespace, Name: instanceName}
 
 		// Wait for PatchingBackupStarted
-		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 45*time.Second)
+		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 2*time.Minute)
 
 		// Wait until the instance is "Ready" again
 		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.CreateComplete, 15*time.Minute)
@@ -116,7 +116,7 @@ var _ = Describe("Agent Patching", func() {
 		instKey := client.ObjectKey{Namespace: k8sEnv.DPNamespace, Name: instanceName}
 
 		// Wait for PatchingBackupStarted
-		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 45*time.Second)
+		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 2*time.Minute)
 
 		// Wait for StatefulSetPatchingInProgress
 		testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.StatefulSetPatchingInProgress, 15*time.Minute)

--- a/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
+++ b/oracle/controllers/inttest/parameterupdatetest/parameter_update_test.go
@@ -101,7 +101,7 @@ var _ = Describe("ParameterUpdate", func() {
 				})
 
 			// Verify the controller is getting into ParameterUpdateInProgress state
-			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.ParameterUpdateInProgress, 60*time.Second)
+			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.ParameterUpdateInProgress, 2*time.Minute)
 
 			// Wait until the instance settles into "Ready" again
 			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.CreateComplete, 20*time.Minute)

--- a/oracle/controllers/inttest/patchingtest/patching_test.go
+++ b/oracle/controllers/inttest/patchingtest/patching_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Patching", func() {
 				})
 
 			// Give controller some time to process
-			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 45*time.Second)
+			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 2*time.Minute)
 
 			// Wait until the instance is "Ready" again
 			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.CreateComplete, 25*time.Minute)
@@ -138,7 +138,7 @@ var _ = Describe("Patching", func() {
 				})
 
 			// Give controller some time to process
-			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 45*time.Second)
+			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionFalse, k8s.PatchingBackupStarted, 2*time.Minute)
 
 			// Wait until the instance is "Ready" again
 			testhelpers.WaitForInstanceConditionState(k8sEnv, instKey, k8s.Ready, metav1.ConditionTrue, k8s.PatchingRecoveryCompleted, 25*time.Minute)


### PR DESCRIPTION
These almost always pass but sometimes a reconcile is delayed by over a minute. Lets wait a couple minutes to give throttling a chance to effectively delay the changes without flaking our tests.

Any further waiting is probably a sign of us under-reconciling somehow so we should be careful before extending these further. But all of these are based on code making specific changes to the instance.spec immediately prior to this wait.

Change-Id: Ia82c55f0766fed41cc3a5bf718734f88ed0acc71