### PR TITLE
Fixup metadata dump with table_exists_action

### DIFF
--- a/oracle/controllers/common.go
+++ b/oracle/controllers/common.go
@@ -151,28 +151,6 @@ func (d *GRPCDatabaseClientFactory) New(ctx context.Context, r client.Reader, na
 	return dbdpb.NewDatabaseDaemonClient(conn), conn.Close, nil
 }
 
-// Contains check whether given "elem" presents in "array"
-func Contains(array []string, elem string) bool {
-	for _, v := range array {
-		if v == elem {
-			return true
-		}
-	}
-	return false
-}
-
-// Filter Returns a slice that doesn't contain element
-func Filter(slice []string, element string) []string {
-	//This implementation isn't the fastest, but it protects against slices containing a single element.
-	result := make([]string, 0, len(slice))
-	for _, s := range slice {
-		if s != element {
-			result = append(result, s)
-		}
-	}
-	return result
-}
-
 // GetBackupGcsPath resolves the actual gcs path based on backup spec.
 func GetBackupGcsPath(backup *v1alpha1.Backup) string {
 	gcsPath := backup.Spec.GcsPath

--- a/oracle/controllers/databasecontroller/BUILD.bazel
+++ b/oracle/controllers/databasecontroller/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//oracle/controllers",
         "//oracle/pkg/agents/common/sql",
         "//oracle/pkg/k8s",
+        "//oracle/pkg/util",
         "@com_github_go_logr_logr//:logr",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/oracle/controllers/databasecontroller/database_controller.go
+++ b/oracle/controllers/databasecontroller/database_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/controllers"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/agents/common/sql"
 	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/k8s"
+	"github.com/GoogleCloudPlatform/elcarro-oracle-operator/oracle/pkg/util"
 )
 
 const (
@@ -151,8 +152,8 @@ func (r *DatabaseReconciler) ReconcileDatabaseDeletion(ctx context.Context, req 
 		}
 
 		// Remove PDB from list of DatabaseNames
-		if controllers.Contains(inst.Status.DatabaseNames, db.Spec.Name) {
-			inst.Status.DatabaseNames = controllers.Filter(inst.Status.DatabaseNames, db.Spec.Name)
+		if util.Contains(inst.Status.DatabaseNames, db.Spec.Name) {
+			inst.Status.DatabaseNames = util.Filter(inst.Status.DatabaseNames, db.Spec.Name)
 		}
 		if err := r.Status().Update(ctx, &inst); err != nil {
 			log.Error(err, "failed to update the Instance status after deleting a Database(PDB)", "DatabaseName", db.Name, "InstanceName", inst.Name)
@@ -267,7 +268,7 @@ func (r *DatabaseReconciler) ReconcileDatabaseCreation(ctx context.Context, req 
 	}
 
 	// check DB name against existing ones to decide whether this is a new DB
-	if !controllers.Contains(inst.Status.DatabaseNames, db.Spec.Name) {
+	if !util.Contains(inst.Status.DatabaseNames, db.Spec.Name) {
 		log.Info("found a new DB", "dbName", db.Spec.Name)
 		inst.Status.DatabaseNames = append(inst.Status.DatabaseNames, db.Spec.Name)
 	} else {

--- a/oracle/pkg/database/dbdaemon/BUILD.bazel
+++ b/oracle/pkg/database/dbdaemon/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//oracle/pkg/agents/common",
+        "//oracle/pkg/agents/common/sql",
         "//oracle/pkg/agents/consts",
         "//oracle/pkg/agents/oracle",
         "//oracle/pkg/agents/pitr",

--- a/oracle/pkg/util/utils.go
+++ b/oracle/pkg/util/utils.go
@@ -169,3 +169,25 @@ func (g *GCSUtilImpl) Delete(ctx context.Context, gcsPath string) error {
 	}
 	return nil
 }
+
+// Contains check whether given "elem" presents in "array"
+func Contains(array []string, elem string) bool {
+	for _, v := range array {
+		if v == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// Filter Returns a slice that doesn't contain element
+func Filter(slice []string, element string) []string {
+	//This implementation isn't the fastest, but it protects against slices containing a single element.
+	result := make([]string, 0, len(slice))
+	for _, s := range slice {
+		if s != element {
+			result = append(result, s)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
This parameter is not compatible with sqlfile dump so we should strip it before dumping the sqlfile for metadata.

Fix missing format function for tablespace creation.

Change-Id: I249ce315bde0b76bd7a888b60c63d614631a6b75