### PR TITLE
Adjust initial seeded database bootstrap

### DIFF
--- a/oracle/pkg/database/provision/bootstrap_database_task.go
+++ b/oracle/pkg/database/provision/bootstrap_database_task.go
@@ -410,7 +410,7 @@ func (task *BootstrapTask) prepDatabase(ctx context.Context) error {
 
 	// /u02/app/oracle/oradata/<CDB name>/temp01.dbf is already part of database in unseeded use case, so it is skipped.
 	if task.isSeeded {
-		tempfile := []string{fmt.Sprintf("ALTER TABLESPACE TEMP ADD TEMPFILE '%s/temp01.dbf' SIZE 1G REUSE AUTOEXTEND ON", task.db.GetDataFilesDir())}
+		tempfile := []string{fmt.Sprintf("ALTER TABLESPACE TEMP ADD TEMPFILE '%s/temp01.dbf' SIZE 512M REUSE AUTOEXTEND ON", task.db.GetDataFilesDir())}
 		sqlResp, err = task.dbdClient.RunSQLPlus(ctx, &dbdpb.RunSQLPlusCMDRequest{
 			Commands: tempfile,
 			Suppress: false,
@@ -538,7 +538,7 @@ func (task *BootstrapTask) createPDBSeedTemp(ctx context.Context) error {
 			"alter session set \"_oracle_script\"=TRUE",
 			"alter pluggable database PDB$SEED close",
 			"alter pluggable database PDB$SEED open read write",
-			fmt.Sprintf("alter tablespace TEMP add tempfile '%s/temp01.dbf' size 500m reuse", filepath.Join(task.db.GetDataFilesDir(), "pdbseed")),
+			fmt.Sprintf("alter tablespace TEMP add tempfile '%s/temp01.dbf' size 512M reuse autoextend on", filepath.Join(task.db.GetDataFilesDir(), "pdbseed")),
 			"alter pluggable database PDB$SEED close",
 			"alter pluggable database PDB$SEED open read only",
 		},


### PR DESCRIPTION
Ensure that when we reuse/create the seed pdb's temp we configure it to autoextend.

Change-Id: If374bdb946da5850ee05466a51eeb031c6c53601