### PR TITLE
Updated image-type from cos to cos_containerd for GKE version >1.23

### DIFF
--- a/oracle/scripts/deploy/install-18c-xe.sh
+++ b/oracle/scripts/deploy/install-18c-xe.sh
@@ -148,7 +148,7 @@ function create_cluster() {
     --machine-type=n1-standard-2 --num-nodes 2 --zone ${ZONE} \
     --scopes gke-default,compute-rw,cloud-platform,https://www.googleapis.com/auth/dataaccessauditlogging \
     --service-account "${GKE_SA_EMAIL}" \
-    --image-type cos \
+    --image-type cos_containerd \
     --addons GcePersistentDiskCsiDriver
   else
     echo "cluster (name=${CLUSTER_NAME} zone=${ZONE}) already exists"

--- a/oracle/scripts/deploy/install.sh
+++ b/oracle/scripts/deploy/install.sh
@@ -179,7 +179,7 @@ function create_cluster() {
     --machine-type=n1-standard-2 --num-nodes 2 --zone ${ZONE} \
     --scopes gke-default,compute-rw,cloud-platform,https://www.googleapis.com/auth/dataaccessauditlogging \
     --service-account "${GKE_SA_EMAIL}" \
-    --image-type cos \
+    --image-type cos_containerd \
     --addons GcePersistentDiskCsiDriver
   else
     echo "cluster (name=${CLUSTER_NAME} zone=${ZONE}) already exists"


### PR DESCRIPTION
As detailed in [About the Docker node image deprecation](https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd) support for the Docker runtime has been removed from GKE from version 1.23 (1.24 for upgrades) and "image-type" should be changed from "cos" to "cos_containerd". See [Docker and containerd node images](https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd#docker_and_containerd_node_images).