### PR TITLE
Use valid bazel testlogs directory

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -127,7 +127,7 @@ test:
 		--test_env=PROW_INT_TEST_SA=${PROW_INT_TEST_SA} \
 		--test_env=PROW_CLUSTER_ZONE=${PROW_CLUSTER_ZONE} \
 		--test_env=ARTIFACTS=${ARTIFACTS} || touch failed
-	if [[ -n "$$ARTIFACTS" ]]; then find ../bazel-testlogs/ -name '*.xml' -o -name '*.log' | xargs cp --parents -t "$$ARTIFACTS/" ; fi
+	if [[ -n "$$ARTIFACTS" ]]; then find ..//bazel-out/k8-fastbuild/testlogs/ -name '*.xml' -o -name '*.log' | xargs cp --parents -t "$$ARTIFACTS/" ; fi
 	if [[ -f "failed" ]]; then rm failed; exit 100; fi
 
 # Run go fmt against code


### PR DESCRIPTION
For some reason, bazel 6.0.0 no longer includes a symlink named bazel-testlogs. As such, we must look for logs using the bazel-out symlink instead.

Change-Id: Ib8e2ee3fe9a7aa5b59866be81cb17a80b09c2092