### PR TITLE
Force Requeue after an Instance reaches CreateComplete state

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -323,7 +323,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 			}
 			k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.CreateComplete, "")
 			inst.Status.ActiveImages = CloneMap(sp.Images)
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 


### PR DESCRIPTION
The CreateComplete status for the k8s.Ready Condition is not a terminal state for an instance. Instances that reach this state should be requeued for Database Bootstrapping.

Change-Id: I5c987cc4db49f534377e68e0a7b4b55c139abf04