### PR TITLE
Only set k8s.Ready to CreateComplete once

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller.go
+++ b/oracle/controllers/instancecontroller/instance_controller.go
@@ -320,10 +320,10 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 		if inst.Status.URL != "" {
 			if !k8s.ConditionReasonEquals(instanceReadyCond, k8s.CreateComplete) {
 				r.Recorder.Eventf(&inst, corev1.EventTypeNormal, "InstanceReady", "Instance has been created successfully. Elapsed Time: %v", elapsed)
+				k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.CreateComplete, "")
+				inst.Status.ActiveImages = CloneMap(sp.Images)
+				return ctrl.Result{Requeue: true}, nil
 			}
-			k8s.InstanceUpsertCondition(&inst.Status, k8s.Ready, v1.ConditionTrue, k8s.CreateComplete, "")
-			inst.Status.ActiveImages = CloneMap(sp.Images)
-			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 


### PR DESCRIPTION
Once an instance transitions to k8s.Ready.CreateComplete, there is no need to update the status repeatedly.

Change-Id: I3706f48d7af704c5a8f02c50187d02f47d7ff2c3