### PR TITLE
Support update sga_target.

### DIFF
--- a/oracle/controllers/config_agent_helpers.go
+++ b/oracle/controllers/config_agent_helpers.go
@@ -59,6 +59,10 @@ var (
 	}
 )
 
+var overrideParamTypeStatic = map[string]bool{
+	"sga_target": true,
+}
+
 // GetLROOperation returns LRO operation for the specified namespace instance and operation id.
 func GetLROOperation(ctx context.Context, dbClientFactory DatabaseClientFactory, r client.Reader, id, namespace, instName string) (*lropb.Operation, error) {
 	dbClient, closeConn, err := dbClientFactory.New(ctx, r, namespace, instName)
@@ -538,7 +542,7 @@ func SetParameter(ctx context.Context, dbClientFactory DatabaseClientFactory, r 
 	}
 
 	isStatic := false
-	if paramType == "FALSE" {
+	if paramType == "FALSE" || overrideParamTypeStatic[key] {
 		klog.InfoS("config_agent_helpers/SetParameter", "parameter_type", "STATIC")
 		command = fmt.Sprintf("%s scope=spfile", command)
 		isStatic = true


### PR DESCRIPTION
In this commit we add support so that when users update sga_target it is treated the same way as when static parameters are updated, ie we edit the spfile and bounce the database.

bug: 259726971

Change-Id: I59bac412fd60a6af5cb49b483cc4951c58f97f57