### PR TITLE
amend dbdclient log lines.

### DIFF
--- a/oracle/controllers/config_agent_helpers.go
+++ b/oracle/controllers/config_agent_helpers.go
@@ -171,7 +171,7 @@ func BounceDatabase(ctx context.Context, r client.Reader, dbClientFactory Databa
 	}
 	defer closeConn()
 
-	klog.InfoS("config_agent_helpers/BounceDatabase", "client", dbClient)
+	klog.InfoS("config_agent_helpers/BounceDatabase shutting down database")
 	_, err = dbClient.BounceDatabase(ctx, &dbdpb.BounceDatabaseRequest{
 		Operation:    dbdpb.BounceDatabaseRequest_SHUTDOWN,
 		DatabaseName: req.Sid,
@@ -257,7 +257,7 @@ func CreateDatabase(ctx context.Context, r client.Reader, dbClientFactory Databa
 		return "", fmt.Errorf("config_agent_helpers/CreateDatabase: failed to create database daemon dbdClient: %v", err)
 	}
 	defer closeConn()
-	klog.InfoS("config_agent_helpers/CreateDatabase", "dbClient", dbClient)
+	klog.InfoS("config_agent_helpers/CreateDatabase: checking CDB state")
 
 	_, err = dbClient.CheckDatabaseState(ctx, &dbdpb.CheckDatabaseStateRequest{IsCdb: true, DatabaseName: req.CdbName, DbDomain: req.DbDomain})
 	if err != nil {
@@ -698,7 +698,7 @@ func CreateUsers(ctx context.Context, r client.Reader, dbClientFactory DatabaseC
 		return "", fmt.Errorf("config_agent_helpers/CreateUsers: failed to create database daemon client: %v", err)
 	}
 	defer closeConn()
-	klog.InfoS("config_agent_helpers/CreateUsers", "client", dbClient)
+	klog.InfoS("config_agent_helpers/CreateUsers: checking CDB state")
 
 	_, err = dbClient.CheckDatabaseState(ctx, &dbdpb.CheckDatabaseStateRequest{IsCdb: true, DatabaseName: req.CdbName, DbDomain: req.DbDomain})
 	if err != nil {
@@ -867,7 +867,7 @@ func BootstrapStandby(ctx context.Context, r client.Reader, dbClientFactory Data
 		return nil, fmt.Errorf("config_agent_helpers/BootstrapStandby: failed to create database daemon client: %v", err)
 	}
 	defer closeConn()
-	klog.InfoS("BootstrapStandby", "client", dbClient)
+	klog.InfoS("BootstrapStandby running")
 	if err := standby.BootstrapStandby(ctx, dbClient); err != nil {
 		return nil, fmt.Errorf("config_agent_helpers/BootstrapStandby: failed to bootstrap standby database : %v", err)
 	}
@@ -922,7 +922,7 @@ func CreateListener(ctx context.Context, r client.Reader, dbClientFactory Databa
 		return fmt.Errorf("config_agent_helpers/CreateListener: failed to create listener: %v", err)
 	}
 	defer closeConn()
-	klog.InfoS("config_agent_helpers/CreateListener", "dbClient", dbClient)
+	klog.InfoS("config_agent_helpers/CreateListener: creating listener")
 
 	_, err = dbClient.CreateListener(ctx, &dbdpb.CreateListenerRequest{
 		DatabaseName: req.Name,
@@ -1020,7 +1020,7 @@ func PhysicalBackup(ctx context.Context, r client.Reader, dbClientFactory Databa
 		return nil, fmt.Errorf("config_agent_helpers/PhysicalBackup: failed to create database daemon client: %v", err)
 	}
 	defer closeConn()
-	klog.InfoS("config_agent_helpers/PhysicalBackup", "dbClient", dbClient)
+	klog.InfoS("config_agent_helpers/PhysicalBackup: creating physical backup")
 
 	sectionSize := resource.NewQuantity(int64(req.SectionSize), resource.DecimalSI)
 	return backup.PhysicalBackup(ctx, &backup.Params{
@@ -1123,7 +1123,7 @@ func CheckStatus(ctx context.Context, r client.Reader, dbClientFactory DatabaseC
 		return nil, fmt.Errorf("config_agent_helpers/CheckStatus: failed to create database daemon client: %v", err)
 	}
 	defer closeConn()
-	klog.V(1).InfoS("config_agent_helpers/CheckStatus", "client", dbClient)
+	klog.V(1).InfoS("config_agent_helpers/CheckStatus: checking if provisioning file exists")
 
 	resp, err := dbClient.FileExists(ctx, &dbdpb.FileExistsRequest{Name: consts.ProvisioningDoneFile})
 	if err != nil {


### PR DESCRIPTION
In this commit we amend log lines that print out the dbdaemon client. As the client does not store any metadata, printing out the interface results in printing out a memory address which is not useful.

Change-Id: Ib64ae1ceaa2c694426fdbf30b612e644c3e24ade