### PR TITLE
Fixed example for using an internal load balancer.

### DIFF
--- a/oracle/config/samples/v1alpha1_instance_gcp_lb.yaml
+++ b/oracle/config/samples/v1alpha1_instance_gcp_lb.yaml
@@ -26,7 +26,7 @@ spec:
     requests:
       memory: 4.0Gi
 
-  dbNetworkServiceOptions:
+  dbLoadBalancerOptions:
     gcp:
       loadBalancerType: Internal
 # Uncomment this section to specify a static load balancer IP address


### PR DESCRIPTION
The example for using an internal load balancer is incorrect. `dbNetworkServiceOptions` must be replaced by `dbLoadBalancerOptions`.