### PR TITLE
Stopped Instance Hang During Deletion.

### DIFF
--- a/oracle/controllers/databasecontroller/BUILD.bazel
+++ b/oracle/controllers/databasecontroller/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//common/api/v1alpha1",
         "//oracle/api/v1alpha1",
         "//oracle/controllers",
+        "//oracle/controllers/instancecontroller",
         "//oracle/pkg/agents/common/sql",
         "//oracle/pkg/k8s",
         "//oracle/pkg/util",


### PR DESCRIPTION
In this commit we fix the hanging instance issue. If a instance is stopped and the user wishes to delete it, we will omit the logic ran that requires a running dbdaemon. This logic is only useful when deleting an individual PDB from a runnin instance, if we are deleting the instance anyways then we do not need to run SQL queries to delete the files associated with a PDB.

bug: 276327664

Change-Id: I844309f78cdf8861560049127e09302f59d9cc9e