### PR TITLE
More robust datapatch behavior

### DIFF
--- a/oracle/pkg/database/dbdaemon/dbdaemon_server_test.go
+++ b/oracle/pkg/database/dbdaemon/dbdaemon_server_test.go
@@ -522,7 +522,7 @@ func TestApplyDataPatch(t *testing.T) {
 	if s.database.(*mockDB).openPDBsCount != 1 {
 		t.Fatalf("error setDatabaseUpgradeModeCount")
 	}
-	if !reflect.DeepEqual(s.osUtil.(*mockOsUtil).commands, []string{"DBHOME/OPatch/datapatch"}) {
+	if !reflect.DeepEqual(s.osUtil.(*mockOsUtil).commands, []string{"DBHOME/OPatch/datapatch", "DBHOME/OPatch/datapatch"}) {
 		t.Fatalf("error s.osUtil.(*mockOsUtil).commands %v", s.osUtil.(*mockOsUtil).commands)
 	}
 


### PR DESCRIPTION
Some patches require upgrade mode while others require normal mode, so we need to attempt datapatch in both modes before failing out. This will just fail if the final normal mode datapatch fails.

bug: 277234547
Change-Id: Ibd379681339e5e72a331cb0bdc3adec00c60637a