### PR TITLE
Handle snapshot error messages better

### DIFF
--- a/oracle/controllers/instancecontroller/instance_controller_patching.go
+++ b/oracle/controllers/instancecontroller/instance_controller_patching.go
@@ -447,7 +447,11 @@ func (r *InstanceReconciler) isPatchingBackupCompleted(ctx context.Context, inst
 		if err != nil || snapshot.Status == nil {
 			return false, err
 		}
-		if !*snapshot.Status.ReadyToUse {
+		status := snapshot.Status
+		if status.Error != nil && status.Error.Message != nil {
+			return false, fmt.Errorf("Snapshot Error: %s", *status.Error.Message)
+		}
+		if status.ReadyToUse != nil && !*status.ReadyToUse {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
We would crash trying to check the ready status if the snapshot failed, instead lets check for the error message and avoid nil dereferences.

bug: 277234547
Change-Id: Ic29110b30b8b98d099c740b98ff930189a4ec1a8