### PR TITLE
feat: Remove cluster cleanup in presubmits

### DIFF
--- a/oracle/Makefile
+++ b/oracle/Makefile
@@ -242,14 +242,10 @@ operator-checks: prepare-prow
 # Prow presubmit job entry point: operator-presubmit
 operator-presubmit: prepare-prow
 	$(MAKE) -j8 buildah-push-all
-	# Remove stale resources from the project
-	scripts/integration_test_cluster/cleanup_integration_test_clusters.sh
-	# Create a new GKE cluster for int tests (can be flaky, if failed retry this step once more)
-	scripts/integration_test_cluster/create_integration_test_cluster.sh || (echo "*** Deleting the cluster and trying to create once more *** "; scripts/integration_test_cluster/delete_integration_test_cluster.sh || true; scripts/integration_test_cluster/create_integration_test_cluster.sh)
-	# Run tests, remove temp cluster in case of failure
-	$(MAKE) test || (scripts/integration_test_cluster/delete_integration_test_cluster.sh; exit 100)
-	# Delete the GKE cluster
-	scripts/integration_test_cluster/delete_integration_test_cluster.sh
+	# Create a new GKE cluster for int tests
+	scripts/integration_test_cluster/create_integration_test_cluster.sh
+	# Run tests
+	$(MAKE) test
 
 # Prow canary test job entry point: operator-canary
 operator-canary: prepare-prow


### PR DESCRIPTION
In this commit we remove the cluster cleanup trigger run after presubmits.

Bug: 305755945
Change-Id: I6a9d71e89ba24c7a4c116bb8e2fc56c0553c4ab5