### PR TITLE
Feat: Attach multiple PVC to Instance.

### DIFF
--- a/common/api/v1alpha1/disk.go
+++ b/common/api/v1alpha1/disk.go
@@ -28,9 +28,7 @@ import (
 // the model can be also adjusted to reflect that).
 type DiskSpec struct {
 	// Name of a disk.
-	// Allowed values are: DataDisk,LogDisk,BackupDisk
 	// +required
-	// +kubebuilder:validation:Enum=DataDisk;LogDisk;BackupDisk
 	Name string `json:"name"`
 
 	// Disk size. If not specified, the defaults are: DataDisk:"100Gi", LogDisk:"150Gi",BackupDisk:"100Gi"

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_configs.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_configs.yaml
@@ -71,11 +71,7 @@ spec:
                         external tools through Kubernetes.
                       type: object
                     name:
-                      description: 'Name of a disk. Allowed values are: DataDisk,LogDisk,BackupDisk'
-                      enum:
-                      - DataDisk
-                      - LogDisk
-                      - BackupDisk
+                      description: Name of a disk.
                       type: string
                     selector:
                       description: A label query over volumes to consider for binding.

--- a/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
+++ b/oracle/config/crd/bases/oracle.db.anthosapis.com_instances.yaml
@@ -225,11 +225,7 @@ spec:
                         external tools through Kubernetes.
                       type: object
                     name:
-                      description: 'Name of a disk. Allowed values are: DataDisk,LogDisk,BackupDisk'
-                      enum:
-                      - DataDisk
-                      - LogDisk
-                      - BackupDisk
+                      description: Name of a disk.
                       type: string
                     selector:
                       description: A label query over volumes to consider for binding.

--- a/oracle/controllers/validationstest/crd_validation_test.go
+++ b/oracle/controllers/validationstest/crd_validation_test.go
@@ -229,14 +229,14 @@ var _ = Describe("Instance CRD Validation rules", func() {
 					disks: []commonv1alpha1.DiskSpec{
 						{Name: "FrisbeeDisk"},
 					},
-					valid: false,
+					valid: true,
 				},
 				{
 					disks: []commonv1alpha1.DiskSpec{
 						{Name: "SystemDisk"},
 						{Name: "DataDisk"},
 					},
-					valid: false,
+					valid: true,
 				},
 			}
 

--- a/oracle/operator.yaml
+++ b/oracle/operator.yaml
@@ -688,11 +688,7 @@ spec:
                         external tools through Kubernetes.
                       type: object
                     name:
-                      description: 'Name of a disk. Allowed values are: DataDisk,LogDisk,BackupDisk'
-                      enum:
-                      - DataDisk
-                      - LogDisk
-                      - BackupDisk
+                      description: Name of a disk.
                       type: string
                     selector:
                       description: A label query over volumes to consider for binding.
@@ -1951,11 +1947,7 @@ spec:
                         external tools through Kubernetes.
                       type: object
                     name:
-                      description: 'Name of a disk. Allowed values are: DataDisk,LogDisk,BackupDisk'
-                      enum:
-                      - DataDisk
-                      - LogDisk
-                      - BackupDisk
+                      description: Name of a disk.
                       type: string
                     selector:
                       description: A label query over volumes to consider for binding.


### PR DESCRIPTION
In this commit we relax the contraint that we only allow disks named DataDisk, LogDisk, and BackupDisk in the DiskSpec field.

Bug: b/323879297
Change-Id: Id8f1d254267413f896c94b51b82e81fb3bd2d92f