### PR TITLE
Feat: Attach multiple PVC to Instance.

### DIFF
--- a/oracle/controllers/common.go
+++ b/oracle/controllers/common.go
@@ -137,6 +137,13 @@ func GetPVCNameAndMount(instName, diskName string) (string, string) {
 	return pvcName, mountLocation
 }
 
+// GetCustomPVCNameAndMount returns PVC names and their corresponding mounts for extra disks.
+func GetCustomPVCNameAndMount(inst *v1alpha1.Instance, diskName string) (string, string) {
+	pvcName := fmt.Sprintf(PvcMountName, inst.GetName(), strings.ToLower(diskName))
+	mountLocation := strings.ToLower(diskName)
+	return pvcName, mountLocation
+}
+
 // New returns a new database daemon client
 func (d *GRPCDatabaseClientFactory) New(ctx context.Context, r client.Reader, namespace, instName string) (dbdpb.DatabaseDaemonClient, func() error, error) {
 	var dbservice = fmt.Sprintf(DbdaemonSvcName, instName)
@@ -162,4 +169,15 @@ func GetBackupGcsPath(backup *v1alpha1.Backup) string {
 		gcsPath = gcsPath + backup.Name
 	}
 	return gcsPath
+}
+
+var reservedDiskNames = map[string]struct{}{
+	"datadisk":   {},
+	"backupdisk": {},
+	"logdisk":    {},
+}
+
+func IsReservedDiskName(diskName string) bool {
+	_, exists := reservedDiskNames[strings.ToLower(diskName)]
+	return exists
 }

--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -305,7 +305,12 @@ func NewPVCs(sp StsParams) ([]corev1.PersistentVolumeClaim, error) {
 			configSpec = &sp.Config.Spec.ConfigSpec
 		}
 		rl := corev1.ResourceList{corev1.ResourceStorage: utils.FindDiskSize(&diskSpec, configSpec, DefaultDiskSpecs, defaultDiskSize)}
-		pvcName, mount := GetPVCNameAndMount(sp.Inst.Name, diskSpec.Name)
+		var pvcName, mount string
+		if IsReservedDiskName(diskSpec.Name) {
+			pvcName, mount = GetPVCNameAndMount(sp.Inst.Name, diskSpec.Name)
+		} else {
+			pvcName, mount = GetCustomPVCNameAndMount(sp.Inst, diskSpec.Name)
+		}
 		var pvc corev1.PersistentVolumeClaim
 
 		// Determine storage class (from disk spec or config)
@@ -365,7 +370,12 @@ func buildPVCMounts(sp StsParams) []corev1.VolumeMount {
 	var diskMounts []corev1.VolumeMount
 
 	for _, diskSpec := range sp.Disks {
-		pvcName, mount := GetPVCNameAndMount(sp.Inst.Name, diskSpec.Name)
+		var pvcName, mount string
+		if IsReservedDiskName(diskSpec.Name) {
+			pvcName, mount = GetPVCNameAndMount(sp.Inst.Name, diskSpec.Name)
+		} else {
+			pvcName, mount = GetCustomPVCNameAndMount(sp.Inst, diskSpec.Name)
+		}
 		diskMounts = append(diskMounts, corev1.VolumeMount{
 			Name:      pvcName,
 			MountPath: fmt.Sprintf("/%s", mount),


### PR DESCRIPTION
In this commit we enable customers to add multiple disks. Users can now add disks with whatever name they so choose, this disk name will also be the volume name that we mount to the database pod.

Bug: b/323879297
Change-Id: I94369c936eff99d89f16f51865cf2d862c867e46