### PR TITLE
#377 Integrated Instance tolerations in monitor PodSpec

### DIFF
--- a/oracle/controllers/resources.go
+++ b/oracle/controllers/resources.go
@@ -271,6 +271,7 @@ func MonitoringPodTemplate(inst *v1alpha1.Instance, monitoringSecret *corev1.Sec
 				},
 			},
 		},
+		Tolerations: inst.Spec.PodSpec.Tolerations,
 		Volumes: []corev1.Volume{{
 			Name: "mon-creds",
 			VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
**Summary**

This PR synchronizes the tolerations of the monitoring deployment with the Oracle instance. Tolerations are already available in the Oracle Instance, but they break the monitoring functionality. This PR adds support for tolerations to the monitoring deployment.


**Background**

Tolerations are used in GKE to taint nodes and ensure a workload is running exclusively on a certain node. Currently, the monitoring deployment uses a Pod Affinity to target the node of the Oracle instance; however, if the Oracle instance is using a toleration, then the node will be tainted and the monitoring pod unable to schedule on it.

This PR copies the tolerations of the Oracle pod into the monitoring PodSpec, so that is able to schedule on the same node as the Oracle instance and expose the monitoring endpoint.