### PR TITLE
Prevent STS recreation on El Carro operator update

### DIFF
--- a/oracle/controllers/instancecontroller/utils.go
+++ b/oracle/controllers/instancecontroller/utils.go
@@ -145,7 +145,7 @@ func (r *InstanceReconciler) stopMonitoringDeployment(ctx context.Context, inst 
 		return err
 	}
 
-	images := CloneMap(r.Images)
+	images := r.InstanceStatefulSetImages(ctx, inst.Spec.Images)
 
 	if err := r.overrideDefaultImages(config, images, inst, log); err != nil {
 		return err

--- a/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
+++ b/oracle/controllers/inttest/physbackuptest/physical_backup_test.go
@@ -45,6 +45,17 @@ type backupTestCase struct {
 	backupSpec   v1alpha1.BackupSpec
 }
 
+var (
+	agentImageTag     = os.Getenv("PROW_IMAGE_TAG")
+	agentImageRepo    = os.Getenv("PROW_IMAGE_REPO")
+	agentImageProject = os.Getenv("PROW_PROJECT")
+	// Base image names, to be combined with PROW_IMAGE_{TAG,REPO}.
+	dbInitImage          = "oracle.db.anthosapis.com/dbinit"
+	loggingSidecarImage  = "oracle.db.anthosapis.com/loggingsidecar"
+	monitoringAgentImage = "oracle.db.anthosapis.com/monitoring"
+	// Used by pitr test directly.
+)
+
 // Made global to be accessible by AfterSuite
 var k8sEnv = testhelpers.K8sOperatorEnvironment{}
 
@@ -60,6 +71,9 @@ var _ = Describe("Instance and Database provisioning", func() {
 			corev1.ResourceMemory: resource.MustParse("7Gi"),
 		},
 	}
+	dbInitImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, dbInitImage, agentImageTag)
+	loggingSidecarImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, loggingSidecarImage, agentImageTag)
+	monitoringAgentImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, monitoringAgentImage, agentImageTag)
 
 	BeforeEach(func() {
 		defer GinkgoRecover()
@@ -191,7 +205,10 @@ var _ = Describe("Instance and Database provisioning", func() {
 		Context("Oracle 23ai FREE", func() {
 			testCase.instanceSpec.Version = "23ai"
 			testCase.instanceSpec.Images = map[string]string{
-				"service": testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"service":         testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"dbinit":          dbInitImage,
+				"logging_sidecar": loggingSidecarImage,
+				"monitoring":      monitoringAgentImage,
 			}
 			BackupTest(testCase)
 		})
@@ -238,7 +255,10 @@ var _ = Describe("Instance and Database provisioning", func() {
 		Context("Oracle 23ai FREE", func() {
 			testCase.instanceSpec.Version = "23ai"
 			testCase.instanceSpec.Images = map[string]string{
-				"service": testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"service":         testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"dbinit":          dbInitImage,
+				"logging_sidecar": loggingSidecarImage,
+				"monitoring":      monitoringAgentImage,
 			}
 			BackupTest(testCase)
 		})
@@ -282,14 +302,20 @@ var _ = Describe("Instance and Database provisioning", func() {
 		Context("Oracle 23ai FREE", func() {
 			testCase.instanceSpec.Version = "23ai"
 			testCase.instanceSpec.Images = map[string]string{
-				"service": testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"service":         testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"dbinit":          dbInitImage,
+				"logging_sidecar": loggingSidecarImage,
+				"monitoring":      monitoringAgentImage,
 			}
 			BackupTest(testCase)
 		})
 		Context("Oracle 19.3 EE", func() {
 			testCase.instanceSpec.Version = "19.3"
 			testCase.instanceSpec.Images = map[string]string{
-				"service": testhelpers.TestImageForVersion("19.3", "EE", ""),
+				"service":         testhelpers.TestImageForVersion("19.3", "EE", ""),
+				"dbinit":          dbInitImage,
+				"logging_sidecar": loggingSidecarImage,
+				"monitoring":      monitoringAgentImage,
 			}
 			BackupTest(testCase)
 		})
@@ -333,7 +359,10 @@ var _ = Describe("Instance and Database provisioning", func() {
 		Context("Oracle 23ai FREE", func() {
 			testCase.instanceSpec.Version = "23ai"
 			testCase.instanceSpec.Images = map[string]string{
-				"service": testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"service":         testhelpers.TestImageForVersion("23ai", "FREE", ""),
+				"dbinit":          dbInitImage,
+				"logging_sidecar": loggingSidecarImage,
+				"monitoring":      monitoringAgentImage,
 			}
 			BackupTest(testCase)
 		})

--- a/oracle/controllers/testhelpers/envtest.go
+++ b/oracle/controllers/testhelpers/envtest.go
@@ -571,6 +571,7 @@ func deployOperator(ctx context.Context, k8sClient client.Client, CPNamespace, D
 	dbInitImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, dbInitImage, agentImageTag)
 	loggingSidecarImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, loggingSidecarImage, agentImageTag)
 	monitoringAgentImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, monitoringAgentImage, agentImageTag)
+
 	operatorImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, operatorImage, agentImageTag)
 	// Global modified for usage in pitr test.
 	PitrAgentImage = fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, PitrAgentImage, agentImageTag)
@@ -931,6 +932,15 @@ func CreateSimpleInstance(k8sEnv K8sOperatorEnvironment, instanceName string, ve
 		cdbName = "FREE"
 	}
 
+	var agentImageTag, agentImageRepo, agentImageProject string
+	agentImageTag = os.Getenv("PROW_IMAGE_TAG")
+	agentImageRepo = os.Getenv("PROW_IMAGE_REPO")
+	agentImageProject = os.Getenv("PROW_PROJECT")
+
+	dbInitImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, dbInitImage, agentImageTag)
+	loggingSidecarImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, loggingSidecarImage, agentImageTag)
+	monitoringAgentImage := fmt.Sprintf("%s/%s/%s:%s", agentImageRepo, agentImageProject, monitoringAgentImage, agentImageTag)
+
 	instance := &v1alpha1.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instanceName,
@@ -956,7 +966,10 @@ func CreateSimpleInstance(k8sEnv K8sOperatorEnvironment, instanceName string, ve
 					},
 				},
 				Images: map[string]string{
-					"service": TestImageForVersion(version, edition, ""),
+					"service":         TestImageForVersion(version, edition, ""),
+					"dbinit":          dbInitImage,
+					"logging_sidecar": loggingSidecarImage,
+					"monitoring":      monitoringAgentImage,
 				},
 				DBLoadBalancerOptions: &commonv1alpha1.DBLoadBalancerOptions{
 					GCP: commonv1alpha1.DBLoadBalancerOptionsGCP{LoadBalancerType: "Internal"},

--- a/oracle/main.go
+++ b/oracle/main.go
@@ -45,15 +45,13 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
-
+	scheme               = runtime.NewScheme()
+	setupLog             = ctrl.Log.WithName("setup")
 	dbInitImage          = flag.String("db_init_image_uri", "gcr.io/elcarro/oracle.db.anthosapis.com/dbinit:latest", "DB POD init binary image URI")
 	serviceImage         = flag.String("service_image_uri", "", "GCR service URI")
 	loggingSidecarImage  = flag.String("logging_sidecar_image_uri", "gcr.io/elcarro/oracle.db.anthosapis.com/loggingsidecar:latest", "Logging Sidecar image URI")
 	monitoringAgentImage = flag.String("monitoring_agent_image_uri", "gcr.io/elcarro/oracle.db.anthosapis.com/monitoring:latest", "Monitoring Agent image URI")
-
-	namespace = flag.String("namespace", "", "TESTING ONLY: Limits controller to watching resources in this namespace only")
+	namespace            = flag.String("namespace", "", "TESTING ONLY: Limits controller to watching resources in this namespace only")
 )
 
 func init() {

--- a/oracle/scripts/install_prow_deps.sh
+++ b/oracle/scripts/install_prow_deps.sh
@@ -30,6 +30,13 @@ curl -fsSL https://storage.googleapis.com/www.bazel.build/bazel-release.pub.gpg 
 mv bazel.gpg /etc/apt/trusted.gpg.d/
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 
+# remove the out of date helm repository, update it with the new buildkite one
+# see https://helm.sh/docs/intro/install/#from-apt-debianubuntu
+# TODO:vitorguidi remove this once the base ods kubekins image is rebuilt against a more recent base kubekins one
+test -f /etc/apt/sources.list.d/helm-stable-debian.list && rm /etc/apt/sources.list.d/helm-stable-debian.list
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+
 # everything we can get from debian packages.
 apt-get update -qq
 apt-get install -y \


### PR DESCRIPTION
### Motivation

### Root cause

The dbinit/logging/monitoring images are tied to the el carro version, and both are present in the statefulset. Whenever the operator is updated, the tag on these images changes, causing the statefulset to detect change in the pod template, thus recreating the instances.

Important to note that this breaks the idempotency assumption of kubernetes operators.


See #382 

### Proposed solution

By pinning these image tags to the instance CRD, we isolate changes in the operator release from causing changes in the statefulset definition, thus solving the problem.

The default images will remain defined in [main.go](https://github.com/GoogleCloudPlatform/elcarro-oracle-operator/blob/2cc86d2efcf6f2e2d139c8e07bd6a5c97d7f051a/oracle/main.go#L51), overriden during [make prepare-release](https://github.com/GoogleCloudPlatform/elcarro-oracle-operator/blob/main/oracle/Makefile#L282), and will be used for the STS if abscent in spec.images for the Instance CRD definition. In case they are defined, they will replace the default images tied to the operator version. This way, backwards compatible behavior is maintained.

### Testing strategy

All unit and integration tests pass our internal prow CI (gerrit PR ID = 158387)

GIST containing all commands that were executed, and evidence that indeed the STS does not get recreated: https://gist.github.com/vitorguidi/8f5968dd6793e1fccc24fdf7fbdae1ea


### Update strategy

1) While still running an old operator version X, edit the instance CRD to define the dbinit/logging/monitoring images to bind to image tags X. This should be a no op.
2) Update the operator. Since it sees the old image versions defined in spec.images for the instance, the change will also be no op.

### Gotchas

install_prow_deps was modified, since the latest image that we run the tests on prow were point to an outdated helm apt repo (https://helm.sh/blog/debian-helm-repository-move/)


Change-Id: I326cf9a2d20f382c18db750941d31cbd1926f781